### PR TITLE
Fix badge to reflect only develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # cardano-shell
 
-#### Develop Branch [!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell)
-
-#### All Branches: [![All Branches Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell)
+| #### Develop Branch | [!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell) |
+|--- |--- |
+| #### All Branches | [![All Branches Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell) |
 
 This is the `cardano-shell` project.
 This project uses Github issues for tracking the project progress.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cardano-shell
 
-[![Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell)
+[![Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell)
 
 This is the `cardano-shell` project.
 This project uses Github issues for tracking the project progress.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cardano-shell
 
-[!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell)
-[![All Branches Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell)
+### Develop Branch: [!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell)
+### All Branches: [![All Branches Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell)
 
 This is the `cardano-shell` project.
 This project uses Github issues for tracking the project progress.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cardano-shell
 
-[![Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell)
+[!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell)
+[![All Branches Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell)
 
 This is the `cardano-shell` project.
 This project uses Github issues for tracking the project progress.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cardano-shell
 
 
-| Develop	| All   |
+| Develop	| Master   |
 |---		|---	|
 | [!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell) | [!["master" Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=master)](https://buildkite.com/input-output-hk/cardano-shell) |
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # cardano-shell
 
-| #### Develop Branch | [!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell) |
-|--- |--- |
-| #### All Branches | [![All Branches Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell) |
+
+| Develop	| All   |
+|---		|---	|
+| [!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell) | [![All Branches Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell) |
 
 This is the `cardano-shell` project.
 This project uses Github issues for tracking the project progress.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 | Develop	| All   |
 |---		|---	|
-| [!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell) | [![All Branches Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell) |
+| [!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell) | [!["master" Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=master)](https://buildkite.com/input-output-hk/cardano-shell) |
 
 This is the `cardano-shell` project.
 This project uses Github issues for tracking the project progress.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # cardano-shell
 
-### Develop Branch: [!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell)
-### All Branches: [![All Branches Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell)
+#### Develop Branch [!["develop" Branch Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg?branch=develop)](https://buildkite.com/input-output-hk/cardano-shell)
+
+#### All Branches: [![All Branches Build status](https://badge.buildkite.com/5e4cd5ff2fd87975136914d037c409618deb4d8ed6579f8635.svg)](https://buildkite.com/input-output-hk/cardano-shell)
 
 This is the `cardano-shell` project.
 This project uses Github issues for tracking the project progress.


### PR DESCRIPTION
This PR fixes the issue with the build badge checking all branches instead of only develop.