### PR TITLE
[GH-44] Bump GHC version to 8.6.3.

### DIFF
--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -5,8 +5,8 @@
 let
 
   nixpkgs = builtins.fetchTarball {
-    url    = "https://github.com/NixOS/nixpkgs/archive/069bf7aee30faf7b3ed773cfae2154d761b2d6c2.tar.gz";
-    sha256 = "1c44vjb60fw2r8ck8yqwkj1w4288wixi59c6w1vazjixa79mvjvg";
+    url    = "https://github.com/NixOS/nixpkgs/archive/6054276a8e6e877f8846c79b0779e3310c495a6b.tar.gz";
+    sha256 = "11mv8an4zikh2hybn11znqcbxazqq32byvvvaymy2xkpww2jnkxp";
   };
 
   pkgs = import nixpkgs { inherit config; };
@@ -17,5 +17,5 @@ in
   haskell.lib.buildStackProject {
     name = "cardano-shell-env";
     buildInputs = [ zlib openssl git ];
-    ghc = haskell.packages.ghc844.ghc;
+    ghc = haskell.packages.ghc863.ghc;
   }

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,7 +19,8 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/4b4457e75303ce352223b9723f7771fac6fe0600/snapshot.yaml
+#resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/4b4457e75303ce352223b9723f7771fac6fe0600/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/f2802079ba2c07c4d408e3c0aa000fc363792398/snapshot.yaml
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -54,6 +55,10 @@ extra-deps:
   - katip-0.7.0.0@sha256:4b30d0643e18d01a3fd264d3d75921b49b2f464336a52fa46fa049107ebbfe04
 
   - time-units-1.0.0@sha256:27cf54091c4a0ca73d504fc11d5c31ab4041d17404fe3499945e2055697746c1
+
+  - ekg-0.4.0.15@sha256:f52d7c00654d72d2ab988255f30adba95a52484ac310bab9c136c64732e69f4b
+
+  - ekg-json-0.1.0.6@sha256:4ff2e9cac213a5868ae8b4a7c72a16a9a76fac14d944ae819b3d838a9725569b
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-shell/issues/44

Bumping GHC.