### PR TITLE
[GH-78] Generalize node IPC so it can be extended.

### DIFF
--- a/app/NodeIPC/Main.hs
+++ b/app/NodeIPC/Main.hs
@@ -3,9 +3,10 @@ module Main
     ) where
 
 import           Cardano.Prelude
-import           Cardano.Shell.NodeIPC (Port (..), startNodeJsIPC)
+import           Cardano.Shell.NodeIPC (Port (..), ProtocolDuration (..),
+                                        startNodeJsIPC)
 
 main :: IO ()
 main = do
     let port = Port 8090
-    startNodeJsIPC port
+    startNodeJsIPC SingleMessage port

--- a/src/Cardano/Shell/NodeIPC.hs
+++ b/src/Cardano/Shell/NodeIPC.hs
@@ -11,6 +11,7 @@ module Cardano.Shell.NodeIPC
     , ReadHandle(..)
     , WriteHandle(..)
      -- * IPC protocol
+    , ProtocolDuration (..)
     , startNodeJsIPC
     , startIPC
      -- ** Exceptions
@@ -36,8 +37,8 @@ import           Cardano.Shell.NodeIPC.Example (exampleWithFD,
                                                 getReadWriteHandles)
 import           Cardano.Shell.NodeIPC.Lib (MessageSendFailure (..), MsgIn (..),
                                             MsgOut (..), NodeIPCException (..),
-                                            Port (..), isHandleClosed,
-                                            isIPCException,
+                                            Port (..), ProtocolDuration (..),
+                                            isHandleClosed, isIPCException,
                                             isNodeChannelCannotBeFound,
                                             isUnreadableHandle,
                                             isUnwritableHandle, startIPC,

--- a/src/Cardano/Shell/NodeIPC/Example.hs
+++ b/src/Cardano/Shell/NodeIPC/Example.hs
@@ -30,7 +30,7 @@ import           System.Posix.Process (exitImmediately, forkProcess)
 import           System.Process (createPipe)
 
 import           Cardano.Shell.NodeIPC.Lib (MsgIn (..), MsgOut (..), Port (..),
-                                            startIPC)
+                                            ProtocolDuration (..), startIPC)
 import           Cardano.Shell.NodeIPC.Message (ReadHandle (..),
                                                 WriteHandle (..), readMessage,
                                                 sendMessage)
@@ -87,7 +87,7 @@ ipcServer clientWriteHandle msgin = do
     (serverReadHandle, serverWriteHandle) <- getReadWriteHandles
     -- Send message to server
     sendMessage serverWriteHandle msgin
-    startIPC serverReadHandle clientWriteHandle nodePort
+    startIPC SingleMessage serverReadHandle clientWriteHandle nodePort
 
 -- | Read message wigh given 'ReadHandle'
 receieveMessages :: ReadHandle -> IO (MsgOut, MsgOut)

--- a/src/Cardano/Shell/NodeIPC/Message.hs
+++ b/src/Cardano/Shell/NodeIPC/Message.hs
@@ -6,6 +6,7 @@ between Daedalus and Cardano-node
 
 module Cardano.Shell.NodeIPC.Message
     ( sendMessage
+    , sendMessageByteString
     , readMessage
     , MessageException(..)
     , ReadHandle(..)
@@ -47,8 +48,11 @@ newtype WriteHandle = WriteHandle
 
 -- | Send JSON message with given 'WriteHandle'
 sendMessage :: (MonadIO m, ToJSON msg) => WriteHandle -> msg -> m ()
-sendMessage (WriteHandle hndl) cmd = liftIO $ do
-    send buildOS $ encode cmd
+sendMessage writeHandle cmd = sendMessageByteString writeHandle (encode cmd)
+
+sendMessageByteString :: (MonadIO m) => WriteHandle -> BSL.ByteString -> m ()
+sendMessageByteString (WriteHandle hndl) byteString = liftIO $ do
+    send buildOS $ byteString
     hFlush hndl
   where
     send :: OS -> BSL.ByteString -> IO ()
@@ -65,6 +69,10 @@ sendMessage (WriteHandle hndl) cmd = liftIO $ do
             ]
     sendLinuxMessage :: BSL.ByteString -> IO ()
     sendLinuxMessage = BSLC.hPutStrLn hndl
+
+
+
+
 
 -- | Read JSON message with given 'ReadHandle'
 readMessage :: (MonadIO m, MonadThrow m, FromJSON msg) => ReadHandle -> m msg


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-shell/issues/85

I can't say I really managed to create what I planned to do, but it's still not bad - the protocol handling function is extracted and I have fixed the IPC behavior when running for a longer time (more than a single message).