### PR TITLE
NodeIPC example removed from Win32 compilation

### DIFF
--- a/cardano-shell.cabal
+++ b/cardano-shell.cabal
@@ -36,9 +36,12 @@ library
     , Cardano.Shell.Presets
     , Cardano.Shell.Features.Logging
   other-modules:
-      Cardano.Shell.NodeIPC.Example
-    , Cardano.Shell.NodeIPC.Lib
+      Cardano.Shell.NodeIPC.Lib
     , Cardano.Shell.NodeIPC.Message
+  if !os(windows)
+    other-modules:
+      Cardano.Shell.NodeIPC.Example
+
   hs-source-dirs:
       app
     , src
@@ -179,7 +182,10 @@ test-suite cardano-shell-test
   other-modules:
       Paths_cardano_shell
       DhallConfigSpec
+  if !os(windows)
+    other-modules:
       NodeIPCSpec
+
   hs-source-dirs:
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N

--- a/src/Cardano/Shell/NodeIPC.hs
+++ b/src/Cardano/Shell/NodeIPC.hs
@@ -3,6 +3,8 @@
 <https://github.com/input-output-hk/cardano-shell/blob/develop/specs/CardanoShellSpec.pdf>
 -}
 
+{-# LANGUAGE CPP #-}
+
 module Cardano.Shell.NodeIPC
     (-- * Data types
       Port(..)
@@ -21,9 +23,11 @@ module Cardano.Shell.NodeIPC
      -- * Used for testing
     , sendMessage
     , readMessage
+#if !defined(mingw32_HOST_OS)
     , exampleWithFD
     , exampleWithProcess
     , getReadWriteHandles
+#endif
     -- * Predicates
     , isIPCException
     , isHandleClosed
@@ -32,9 +36,11 @@ module Cardano.Shell.NodeIPC
     , isNodeChannelCannotBeFound
     ) where
 
+#if !defined(mingw32_HOST_OS)
 import           Cardano.Shell.NodeIPC.Example (exampleWithFD,
                                                 exampleWithProcess,
                                                 getReadWriteHandles)
+#endif
 import           Cardano.Shell.NodeIPC.Lib (MessageSendFailure (..), MsgIn (..),
                                             MsgOut (..), NodeIPCException (..),
                                             Port (..), ProtocolDuration (..),


### PR DESCRIPTION
Signed-off-by: Alexander Diemand <codieplusplus@apax.net>

make it compatible with Win32