### PR TITLE
Fix various `CardanoConfiguration` types

### DIFF
--- a/src/Cardano/Shell/Constants/Types.hs
+++ b/src/Cardano/Shell/Constants/Types.hs
@@ -100,7 +100,7 @@ data Initializer = Initializer
 
 -- | These options determine balances of nodes specific for testnet.
 data TestBalance = TestBalance
-    { tePoors          :: !Int
+    { tePoors          :: !Word
       -- ^ Number of poor nodes (with small balance).
     , teRichmen        :: !Word
       -- ^ Number of rich nodes (with huge balance).
@@ -108,7 +108,7 @@ data TestBalance = TestBalance
       -- ^ Portion of stake owned by all richmen together.
     , teUseHDAddresses :: !Bool
       -- ^ Whether generate plain addresses or with hd payload.
-    , teTotalBalance   :: !Int
+    , teTotalBalance   :: !Word64
       -- ^ Total balance owned by these nodes.
     } deriving (Eq, Show)
 
@@ -126,26 +126,26 @@ data ModuleAutoRestart
     deriving (Eq, Show)
 
 data BlockVersionData = BlockVersionData
-    { bvdScriptVersion     :: !Int
+    { bvdScriptVersion     :: !Word16
     , bvdSlotDuration      :: !Int
-    , bvdMaxBlockSize      :: !Int
-    , bvdMaxHeaderSize     :: !Int
-    , bvdMaxTxSize         :: !Int
-    , bvdMaxProposalSize   :: !Int
-    , bvdMpcThd            :: !Float
-    , bvdHeavyDelThd       :: !Float
-    , bvdUpdateVoteThd     :: !Float
-    , bvdUpdateProposalThd :: !Float
-    , bvdUpdateImplicit    :: !Int
+    , bvdMaxBlockSize      :: !Natural
+    , bvdMaxHeaderSize     :: !Natural
+    , bvdMaxTxSize         :: !Natural
+    , bvdMaxProposalSize   :: !Natural
+    , bvdMpcThd            :: !Word64
+    , bvdHeavyDelThd       :: !Word64
+    , bvdUpdateVoteThd     :: !Word64
+    , bvdUpdateProposalThd :: !Word64
+    , bvdUpdateImplicit    :: !Word64
     , bvdSoftforkRule      :: !SoftForkRule
     , bvdTXFeePolicy       :: !TxFeePolicy
-    , bvdUnlockStakeEpoch  :: !Integer
+    , bvdUnlockStakeEpoch  :: !Word64
     } deriving (Eq, Show)
 
 data SoftForkRule = SoftForkRule
-    { sfrInitThd      :: !Float
-    , sfrMinThd       :: !Float
-    , sfrThdDecrement :: !Float
+    { sfrInitThd      :: !Word64
+    , sfrMinThd       :: !Word64
+    , sfrThdDecrement :: !Word64
     } deriving (Eq, Show)
 
 data TxFeePolicy = TxFeePolicy
@@ -153,14 +153,14 @@ data TxFeePolicy = TxFeePolicy
     } deriving (Eq, Show)
 
 data TxSizeLinear = TxSizeLinear
-    { txsA :: !Int
-    , txsB :: !Float
+    { txsA :: !Word64
+    , txsB :: !Word64
     } deriving (Eq, Show)
 
 data ProtocolConstants = ProtocolConstants
-    { prK             :: !Int
+    { prK             :: !Word64
     -- ^ Security parameter from the paper.
-    , prProtocolMagic :: !Int
+    , prProtocolMagic :: !Word32
     -- ^ Magic constant for separating real/testnet.
     } deriving (Eq, Show)
 

--- a/src/Cardano/Shell/Presets.hs
+++ b/src/Cardano/Shell/Presets.hs
@@ -101,7 +101,7 @@ mainnetConfiguration =
                 , geSrc      = "mainnet-genesis.json"
                 , geFileHash = "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
                 }
-          , coRequiresNetworkMagic = "NetworkMainOrStage"
+          , coRequiresNetworkMagic = "RequiresNoMagic"
           , coDBSerializeVersion   = 0
           }
     , ccNTP =
@@ -249,23 +249,23 @@ devConfiguration =
                   , bvdMaxHeaderSize     = 2000000
                   , bvdMaxTxSize         = 4096
                   , bvdMaxProposalSize   = 700
-                  , bvdMpcThd            = 0.01
-                  , bvdHeavyDelThd       = 0.005
-                  , bvdUpdateVoteThd     = 0.001
-                  , bvdUpdateProposalThd = 0.1
+                  , bvdMpcThd            = 10
+                  , bvdHeavyDelThd       = 5
+                  , bvdUpdateVoteThd     = 1
+                  , bvdUpdateProposalThd = 100
                   , bvdUpdateImplicit    = 10
                   , bvdSoftforkRule      =
                     SoftForkRule
-                      { sfrInitThd      = 0.9
-                      , sfrMinThd       = 0.6
-                      , sfrThdDecrement = 0.05
+                      { sfrInitThd      = 90
+                      , sfrMinThd       = 60
+                      , sfrThdDecrement = 5
                       }
                   , bvdTXFeePolicy       =
                     TxFeePolicy
                       { txfTXSizeLinear =
                         TxSizeLinear
                           { txsA = 155381
-                          , txsB = 43.946
+                          , txsB = 43
                           }
                       }
                   , bvdUnlockStakeEpoch = 18446744073709551615


### PR DESCRIPTION
- When parsing `CardanoConfiguration` to see if we require a `NetworkMagic` value, we look for either `"RequiresMagic"` (for testnet) or `"RequiresNoMagic"` (for mainnet or staging).

- Change other types in `CardanoConfiguration` to match their corresponding types in `cardano-ledger`.

