### PR TITLE
Use new shellFor function to provide build env.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,12 +60,12 @@ in defaultNix // {
     # env will provide the dependencies of cardano-shell
     packages = ps: with ps; [ cardano-shell ];
     # This adds git to the shell, which is used by stack.
-    buildInputs = with pkgs; [ git ];
+    buildInputs = with pkgs; [ git stack commonLib.stack-hpc-coveralls ];
   };
 
   runCoveralls = pkgs.stdenv.mkDerivation {
     name = "run-coveralls";
-    buildInputs = with pkgs; [ haskellPackages.stack-hpc-coveralls stack ];
+    buildInputs = with pkgs; [ commonLib.stack-hpc-coveralls stack ];
     shellHook = ''
       echo '~~~ stack test'
       stack test --coverage

--- a/default.nix
+++ b/default.nix
@@ -41,14 +41,27 @@ in
 # parameterize this file when targetting different
 # hosts.
 { system ? builtins.currentSystem
+, crossSystem ? null
 , config ? {}
-, pkgs ? commonLib.getPkgs { inherit config system; }
-, ... }@args:
-# We will instantiate the default-nix template with the
-# nix/pkgs.nix file...
-commonLib.nix-tools.default-nix ./nix/pkgs.nix args
-# ... and add additional non-haskell packages we want to build on CI:
-// {
+, pkgs ? commonLib.getPkgs { inherit config crossSystem system; }
+, withHoogle ? true
+}:
+let 
+  # We will instantiate the default-nix template with the
+  # nix/pkgs.nix file...
+  defaultNix = commonLib.nix-tools.default-nix ./nix/pkgs.nix { 
+    inherit system crossSystem config pkgs;
+  };
+in defaultNix // {
+  # ... and add additional packages we want to build on CI:
+
+  env = defaultNix.nix-tools.shellFor {
+    inherit withHoogle;
+    # env will provide the dependencies of cardano-shell
+    packages = ps: with ps; [ cardano-shell ];
+    # This adds git to the shell, which is used by stack.
+    buildInputs = with pkgs; [ git ];
+  };
 
   runCoveralls = pkgs.stdenv.mkDerivation {
     name = "run-coveralls";

--- a/nix/iohk-nix-src.json
+++ b/nix/iohk-nix-src.json
@@ -1,7 +1,7 @@
 {
   "url": "https://github.com/input-output-hk/iohk-nix",
-  "rev": "5040e0192871203251ed404edb3c9259c18bc7e1",
-  "date": "2019-05-20T19:03:56-03:00",
-  "sha256": "1ah1njfj906068g0z10x5ldphcx4l1dx7y026vhmqyjhyqgml88q",
+  "rev": "8a7faeddf108515a8d64cb3dcf552bbd432865a3",
+  "date": "2019-05-31T03:32:45+00:00",
+  "sha256": "0cjsnzfnyhbvjvw9lk2z6bznjnpq452d629319km29yvqqg2n9yk",
   "fetchSubmodules": false
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 let
   localPkgs = import ./. { };
-  mainShell = localPkgs.nix-tools.libs.cardano-shell;
+  mainShell = localPkgs.env;
 in mainShell // {
   inherit (localPkgs) runCoveralls;
 }

--- a/stack-shell.nix
+++ b/stack-shell.nix
@@ -1,0 +1,1 @@
+(import ./. { withHoogle = false; }).env

--- a/stack.yaml
+++ b/stack.yaml
@@ -96,5 +96,4 @@ extra-deps:
 
 nix:
   enable: true
-  pure: false
-  shell-file: shell.nix
+  shell-file: stack-shell.nix


### PR DESCRIPTION
Only build dependencies, allow pure stack build.
(followup on https://github.com/input-output-hk/cardano-shell/pull/83#issuecomment-494381029)
