### PR TITLE
[GH-176] Add coveralls CI build coverage.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,15 @@
 steps:
+  - label: 'stack coveralls coverage'
+    command:
+      - 'nix-shell -A runCoveralls'
+    agents:
+      system: x86_64-linux
+
   - label: 'check-hydra'
     command: 'ci/check-hydra.sh'
     agents:
       system: x86_64-linux
+
   - label: 'stack2nix'
     command: 'ci/check-regenerate-nix.sh'
     agents:

--- a/default.nix
+++ b/default.nix
@@ -67,8 +67,8 @@ in defaultNix // {
     name = "run-coveralls";
     buildInputs = with pkgs; [ commonLib.stack-hpc-coveralls stack ];
     shellHook = ''
-      echo '~~~ stack test'
-      stack test --coverage
+      echo '~~~ stack nix test'
+      stack test --nix --coverage
       echo '~~~ shc'
       shc --repo-token=$COVERALLS_REPO_TOKEN cardano-shell cardano-shell-test
       exit


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-shell/issues/176

Adding the Coveralls test coverage (using Nix).