### PR TITLE
adapt startIPC so it can take any fromjson/tojson message pair

### DIFF
--- a/cardano-shell.cabal
+++ b/cardano-shell.cabal
@@ -28,6 +28,7 @@ library
     , Cardano.Shell.Configuration.Lib
     -- NodeIPC
     , Cardano.Shell.NodeIPC
+    , Cardano.Shell.NodeIPC.SimplePortServer
     -- Update system
     , CardanoShellSpec
     , Cardano.Shell.Update.Types

--- a/src/Cardano/Shell/NodeIPC.hs
+++ b/src/Cardano/Shell/NodeIPC.hs
@@ -43,21 +43,20 @@ module Cardano.Shell.NodeIPC
     ) where
 
 import           Cardano.Shell.NodeIPC.Lib (ClientHandles (..),
-                                            MessageSendFailure (..), MsgIn (..),
-                                            MsgOut (..), NodeIPCException (..),
+                                            MessageSendFailure (..),
+                                            NodeIPCException (..),
                                             Port (..), ProtocolDuration (..),
                                             ServerHandles (..),
                                             bracketFullDuplexAnonPipesHandles,
                                             clientIPCListener,
                                             closeFullDuplexAnonPipesHandles,
                                             createFullDuplexAnonPipesHandles,
-                                            handleIPCProtocol, isHandleClosed,
+                                            isHandleClosed,
                                             isIPCException,
                                             isNodeChannelCannotBeFound,
                                             isUnreadableHandle,
                                             isUnwritableHandle, serverReadWrite,
-                                            startIPC, startNodeJsIPC,
-                                            testStartNodeIPC)
+                                            startIPC, startNodeJsIPC)
 import           Cardano.Shell.NodeIPC.Message (MessageException (..),
                                                 ReadHandle (..),
                                                 WriteHandle (..), readMessage,
@@ -66,3 +65,4 @@ import           Cardano.Shell.NodeIPC.ServerExample (exampleServerWithProcess,
                                                       exampleWithFD,
                                                       getHandleFromEnv,
                                                       getReadWriteHandles)
+import Cardano.Shell.NodeIPC.SimplePortServer

--- a/src/Cardano/Shell/NodeIPC/ServerExample.hs
+++ b/src/Cardano/Shell/NodeIPC/ServerExample.hs
@@ -26,9 +26,10 @@ module Cardano.Shell.NodeIPC.ServerExample
 
 import           Cardano.Prelude
 
-import           Cardano.Shell.NodeIPC.Lib (MsgIn (..), MsgOut (..),
+import           Cardano.Shell.NodeIPC.Lib (
                                             NodeIPCException (..), Port (..),
                                             ProtocolDuration (..), startIPC)
+import           Cardano.Shell.NodeIPC.SimplePortServer ()
 import           Cardano.Shell.NodeIPC.Message (ReadHandle (..),
                                                 WriteHandle (..), readMessage,
                                                 sendMessage)
@@ -39,6 +40,7 @@ import           System.Environment (lookupEnv, setEnv, unsetEnv)
 import           System.IO (BufferMode (..), hClose, hSetBuffering)
 import           System.Process (CreateProcess (..), StdStream (..), createPipe,
                                  createPipeFd, proc, withCreateProcess)
+import Cardano.Shell.NodeIPC.SimplePortServer
 
 -- | Create a pipe for interprocess communication and return a
 -- ('ReadHandle', 'WriteHandle') Handle pair.
@@ -68,7 +70,7 @@ exampleWithFD msgin = do
         (clientReadHandle, clientWriteHandle) <- getReadWriteHandles
         -- Send message to client
         sendMessage clientWriteHandle msgin
-        startIPC SingleMessage clientReadHandle serverWriteHandle nodePort
+        startIPC SingleMessage clientReadHandle serverWriteHandle (handleIPCProtocol nodePort)
         `concurrently`
         receieveMessages serverReadHandle
 

--- a/src/Cardano/Shell/NodeIPC/SimplePortServer.hs
+++ b/src/Cardano/Shell/NodeIPC/SimplePortServer.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE RankNTypes          #-}
+
+module Cardano.Shell.NodeIPC.SimplePortServer
+  ( handleIPCProtocol
+  , testStartNodeIPC
+  , MsgIn(..)
+  , MsgOut(..)
+  ) where
+
+import           Cardano.Prelude
+
+import           Test.QuickCheck (Arbitrary (..), Gen, arbitraryASCIIChar,
+                                  choose, elements, listOf1)
+import           Data.Aeson (FromJSON (parseJSON), ToJSON (toEncoding),
+                             defaultOptions, genericParseJSON,
+                             genericToEncoding)
+import           Data.Aeson.Types (Options, SumEncoding (ObjectWithSingleField),
+                                   sumEncoding)
+import Cardano.Shell.NodeIPC.Lib
+import           Cardano.Shell.NodeIPC.Message (MessageException,
+                                                ReadHandle (..),
+                                                WriteHandle (..), readMessage,
+                                                sendMessage)
+
+opts :: Options
+opts = defaultOptions { sumEncoding = ObjectWithSingleField }
+
+-- | Message from the server being sent to the client.
+data MsgIn
+    = QueryPort
+    -- ^ Ask which port to use
+    | Ping
+    -- ^ Ping
+    | Shutdown
+    -- ^ Shutdown message from the server
+    | MessageInFailure MessageSendFailure
+    deriving (Show, Eq, Generic)
+
+instance Arbitrary MsgIn where
+    arbitrary = elements [QueryPort, Ping]
+
+-- | Message which is send out from Cardano-node
+data MsgOut
+    = Started
+    -- ^ Notify Daedalus that the node has started
+    | ReplyPort Word16
+    -- ^ Reply of QueryPort
+    | Pong
+    -- ^ Reply of Ping
+    | ShutdownInitiated
+    -- ^ Reply of shutdown
+    | MessageOutFailure MessageSendFailure
+    deriving (Show, Eq, Generic)
+
+instance Arbitrary MsgOut where
+    arbitrary = do
+        safeText   <- genSafeText
+        randomPort <- choose (1000,10000)
+        elements
+            [ Started
+            , ReplyPort randomPort
+            , Pong
+            , MessageOutFailure $ ParseError safeText
+            ]
+        where
+          genSafeText :: Gen Text
+          genSafeText = strConv Lenient <$> listOf1 arbitraryASCIIChar
+
+instance ToJSON   MsgIn  where
+    toEncoding = genericToEncoding opts
+
+instance FromJSON MsgIn  where
+    parseJSON = genericParseJSON opts
+
+instance ToJSON   MsgOut where
+    toEncoding = genericToEncoding opts
+
+instance FromJSON MsgOut where
+    parseJSON = genericParseJSON opts
+
+-- | Function for handling the protocol
+handleIPCProtocol :: forall m. (MonadIO m) => Port -> MsgIn -> m MsgOut
+handleIPCProtocol (Port port) = \case
+    QueryPort          -> pure (ReplyPort port)
+    Ping               -> pure Pong
+    -- Send message, flush buffer, shutdown. Since it's complicated to reason with another
+    -- thread that shuts down the program after some time, we do it immediately.
+    Shutdown           -> return ShutdownInitiated >> liftIO $ exitWith (ExitFailure 22)
+    MessageInFailure f -> pure $ MessageOutFailure f
+
+-- | Test 'startIPC'
+testStartNodeIPC :: (ToJSON a, FromJSON b) => Port -> a -> IO (b, b)
+testStartNodeIPC port msg = do
+    (clientReadHandle, clientWriteHandle) <- getReadWriteHandles
+    (serverReadHandle, serverWriteHandle) <- getReadWriteHandles
+
+    -- Start the server
+    (_, responses) <-
+        startIPC
+            SingleMessage
+            serverReadHandle
+            clientWriteHandle
+            (handleIPCProtocol port)
+        `concurrently`
+        do
+            -- Use these functions so you don't pass the wrong handle by mistake
+            let readClientMessage :: FromJSON b => IO b
+                readClientMessage = readMessage clientReadHandle
+
+            let sendServer :: (ToJSON msg) => msg -> IO ()
+                sendServer = sendMessage serverWriteHandle
+
+            -- Communication starts here
+            started     <- readClientMessage
+            sendServer msg
+            response    <- readClientMessage
+            return (started, response)
+
+    return responses

--- a/test/NodeIPCSMSpec.hs
+++ b/test/NodeIPCSMSpec.hs
@@ -35,6 +35,7 @@ import           Cardano.Shell.NodeIPC (MessageSendFailure (..), MsgIn (..),
                                         Port (..), ProtocolDuration (..),
                                         ServerHandles (..), clientIPCListener,
                                         closeFullDuplexAnonPipesHandles,
+                                        handleIPCProtocol,
                                         createFullDuplexAnonPipesHandles,
                                         readMessage, serverReadWrite)
 
@@ -78,7 +79,7 @@ withServerHandles runServer = do
 
     -- Create the IPC server, it's using async, but it can be a separate process.
     clientIPCAsync                  <-
-        liftIO $ async $ clientIPCListener MultiMessage clientHandles (Port port)
+        liftIO $ async $ clientIPCListener MultiMessage clientHandles (handleIPCProtocol $ Port port)
 
     -- Communication starts here
     started <- run $ readMessage (getServerReadHandle serverHandles)


### PR DESCRIPTION
this PR moves the handler for the IPC into `Cardano.Shell.NodeIPC.SimplePortServer` along with the types for the protocol

and then adapts all related code to take a handler and generic `FromJSON` and `ToJSON` types, so that another program can just provide its own replacement of `Cardano.Shell.NodeIPC.SimplePortServer` and reuse the bulk of the logic

todo:
- [ ] rebase once https://github.com/input-output-hk/cardano-shell/pull/186 is merged
- [ ] clean up imports and stylish-haskell
- [ ] replace `stack exec node-ipc` with `$(stack path --local-install-root)/bin/node-ipc` so the haskell mode with stdin/out isnt needed