### PR TITLE
 Next step in the partial-options-monoid implementation

### DIFF
--- a/app/Cardano/Shell/Features/Networking.hs
+++ b/app/Cardano/Shell/Features/Networking.hs
@@ -76,7 +76,7 @@ createNetworkingFeature loggingLayer cardanoEnvironment cardanoConfiguration = d
     -- the filesystem, so we give him the most flexible/powerful context, @IO@.
     networkingConfiguration <-  pure "THIS IS AN EXAMPLE OF A CONFIGURATION!"
 
-    putTextLn $ "The DB version" <> (show $ coDBSerializeVersion <$> ccCore cardanoConfiguration)
+    putTextLn $ "The DB version" <> (show $ coDBSerializeVersion $ ccCore cardanoConfiguration)
 
     -- we construct the layer
     networkingLayer         <- (featureInit networkingCardanoFeatureInit) cardanoEnvironment loggingLayer cardanoConfiguration networkingConfiguration

--- a/default.nix
+++ b/default.nix
@@ -60,7 +60,14 @@ in defaultNix // {
     # env will provide the dependencies of cardano-shell
     packages = ps: with ps; [ cardano-shell ];
     # This adds git to the shell, which is used by stack.
-    buildInputs = with pkgs; [ git stack commonLib.stack-hpc-coveralls pkgconfig systemd ];
+    buildInputs = with pkgs; [
+      defaultNix.nix-tools._raw.cabal-install.components.exes.cabal
+      git
+      pkgconfig
+      stack
+      commonLib.stack-hpc-coveralls
+      systemd
+    ];
   };
 
   runCoveralls = pkgs.stdenv.mkDerivation {

--- a/src/Cardano/Shell/Configuration/Lib.hs
+++ b/src/Cardano/Shell/Configuration/Lib.hs
@@ -42,41 +42,43 @@ lastToEither errMsg (Last x) = maybe (Left errMsg) Right x
 -- in the partial options monoid approach, after all the parametrisation layers have been merged,
 -- and we're intending to use the resultant config -- they ensure that all values are defined.
 --
+-- NOTE: we should look into applying generic programming and/or TH for this boilerlate.
+--
 finaliseCardanoConfiguration :: PartialCardanoConfiguration -> Either Text CardanoConfiguration
 finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
-  ccLogPath                <- lastToEither "Unspecified ccLogPath"      pccLogPath
-  ccLogConfig              <- lastToEither "Unspecified ccLogConfig"    pccLogConfig
-  ccDBPath                 <- lastToEither "Unspecified ccDBPath"       pccDBPath
-  ccApplicationLockFile    <- lastToEither "Unspecified ccApplicationLockFile"
-                                                                        pccApplicationLockFile
-  ccCore                   <- join $ finaliseCore <$>
-                              lastToEither "Unspecified ccCore"         pccCore
-  ccNTP                    <- lastToEither "Unspecified ccNTP"          pccNTP
-  ccUpdate                 <- lastToEither "Unspecified ccUpdate"       pccUpdate
-  ccTXP                    <- lastToEither "Unspecified ccTXP"          pccTXP
-  ccSSC                    <- lastToEither "Unspecified ccSSC"          pccSSC
-  ccDLG                    <- lastToEither "Unspecified ccDLG"          pccDLG
-  ccBlock                  <- lastToEither "Unspecified ccBlock"        pccBlock
-  ccNode                   <- lastToEither "Unspecified ccNode"         pccNode
-  ccTLS                    <- lastToEither "Unspecified ccTLS"          pccTLS
-  ccWallet                 <- lastToEither "Unspecified ccWallet"       pccWallet
-
-  pure CardanoConfiguration{..}
+    ccLogPath                <- lastToEither "Unspecified ccLogPath"      pccLogPath
+    ccLogConfig              <- lastToEither "Unspecified ccLogConfig"    pccLogConfig
+    ccDBPath                 <- lastToEither "Unspecified ccDBPath"       pccDBPath
+    ccApplicationLockFile    <- lastToEither "Unspecified ccApplicationLockFile"
+                                                                          pccApplicationLockFile
+    ccCore                   <- join $ finaliseCore <$>
+                                lastToEither "Unspecified ccCore"         pccCore
+    ccNTP                    <- lastToEither "Unspecified ccNTP"          pccNTP
+    ccUpdate                 <- lastToEither "Unspecified ccUpdate"       pccUpdate
+    ccTXP                    <- lastToEither "Unspecified ccTXP"          pccTXP
+    ccSSC                    <- lastToEither "Unspecified ccSSC"          pccSSC
+    ccDLG                    <- lastToEither "Unspecified ccDLG"          pccDLG
+    ccBlock                  <- lastToEither "Unspecified ccBlock"        pccBlock
+    ccNode                   <- lastToEither "Unspecified ccNode"         pccNode
+    ccTLS                    <- lastToEither "Unspecified ccTLS"          pccTLS
+    ccWallet                 <- lastToEither "Unspecified ccWallet"       pccWallet
+  
+    pure CardanoConfiguration{..}
 
 finaliseCore :: PartialCore -> Either Text Core
 finaliseCore PartialCore{..} = do
-  coGenesis                 <- join $ finaliseGenesis <$>
-                               lastToEither "Unspecified coGenesis"                 pcoGenesis
-  coRequiresNetworkMagic    <- lastToEither "Unspecified coRequiresNetworkMagic"    pcoRequiresNetworkMagic
-  coDBSerializeVersion      <- lastToEither "Unspecified coDBSerializeVersion"      pcoDBSerializeVersion
-  pure Core{..}
+    coGenesis                <- join $ finaliseGenesis <$>
+                                lastToEither "Unspecified coGenesis"                 pcoGenesis
+    coRequiresNetworkMagic   <- lastToEither "Unspecified coRequiresNetworkMagic"    pcoRequiresNetworkMagic
+    coDBSerializeVersion     <- lastToEither "Unspecified coDBSerializeVersion"      pcoDBSerializeVersion
+    pure Core{..}
 
 finaliseGenesis :: PartialGenesis -> Either Text Genesis
 finaliseGenesis PartialGenesis{..} = do
-  geSrc                     <- lastToEither "Unspecified geSrc"                     pgeSrc
-  geGenesisHash             <- lastToEither "Unspecified geGenesisHash"             pgeGenesisHash
-  gePrevBlockHash           <- lastToEither "Unspecified gePrevBlockHash"           pgePrevBlockHash
-  pure Genesis{..}
+    geSrc                    <- lastToEither "Unspecified geSrc"                     pgeSrc
+    geGenesisHash            <- lastToEither "Unspecified geGenesisHash"             pgeGenesisHash
+    gePrevBlockHash          <- lastToEither "Unspecified gePrevBlockHash"           pgePrevBlockHash
+    pure Genesis{..}
 
 -- | Generate 'TopologyConfig' with given 'Cluster'
 mkTopology :: Cluster -> IO TopologyConfig

--- a/src/Cardano/Shell/Constants/CLI.hs
+++ b/src/Cardano/Shell/Constants/CLI.hs
@@ -63,8 +63,8 @@ parseGenesis :: Parser PartialGenesis
 parseGenesis =
     PartialGenesis
         <$> lastStrOption
-           ( long "src-file-path"
-          <> metavar "SRC-FILE-PATH"
+           ( long "genesis-file"
+          <> metavar "FILEPATH"
           <> help "The filepath to the genesis file."
            )
         <*> lastStrOption

--- a/src/Cardano/Shell/Constants/CLI.hs
+++ b/src/Cardano/Shell/Constants/CLI.hs
@@ -19,13 +19,16 @@ import           Cardano.Shell.Constants.Types
 lastOption :: Parser a -> Parser (Last a)
 lastOption parser = Last <$> optional parser
 
+lastStrOption :: IsString a => Mod OptionFields a -> Parser (Last a)
+lastStrOption args = Last <$> optional (strOption args)
+
 --------------------------------------------------------------------------------
 -- Core
 --------------------------------------------------------------------------------
 
 -- | The parser for the logging specific arguments.
-configCoreCLIParser :: Parser Core
-configCoreCLIParser = Core
+configCoreCLIParser :: Parser PartialCore
+configCoreCLIParser = PartialCore
     <$> lastOption parseGenesis
     <*> lastOption parseNetworkMagic
     <*> lastOption parseDBVersion
@@ -56,20 +59,20 @@ parseDBVersion =
         )
 
 -- | CLI parser for @Genesis@.
-parseGenesis :: Parser Genesis
+parseGenesis :: Parser PartialGenesis
 parseGenesis =
-    Genesis
-        <$> strOption
+    PartialGenesis
+        <$> lastStrOption
            ( long "src-file-path"
           <> metavar "SRC-FILE-PATH"
           <> help "The filepath to the genesis file."
            )
-        <*> strOption
+        <*> lastStrOption
            ( long "genesis-hash"
           <> metavar "GENESIS-HASH"
           <> help "The genesis hash value."
            )
-        <*> strOption
+        <*> lastStrOption
            ( long "prev-block-hash"
           <> metavar "PREV-BLOCK-HASH"
           <> help "The hash of the previous block."

--- a/src/Cardano/Shell/Constants/Types.hs
+++ b/src/Cardano/Shell/Constants/Types.hs
@@ -1,11 +1,12 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Cardano.Shell.Constants.Types
-    ( CardanoConfiguration (..)
-    , Core (..)
+    ( CardanoConfiguration (..), PartialCardanoConfiguration (..)
+    , Core (..), PartialCore (..)
     -- * specific for @Core@
     , RequireNetworkMagic (..)
-    , Genesis (..)
+    , Genesis (..), PartialGenesis (..)
     , Spec (..)
     , Initializer (..)
     -- * rest
@@ -49,7 +50,7 @@ data CardanoConfiguration = CardanoConfiguration
     -- ^ The location of the application lock file that is used
     -- as a semaphore se we can run just one application
     -- instance at a time.
-    , ccCore                :: !(Last Core)
+    , ccCore                :: !Core
     , ccNTP                 :: !NTP
     , ccUpdate              :: !Update
     , ccTXP                 :: !TXP
@@ -61,6 +62,23 @@ data CardanoConfiguration = CardanoConfiguration
     , ccWallet              :: !Wallet
     } deriving (Eq, Show)
 
+data PartialCardanoConfiguration = PartialCardanoConfiguration
+    { pccLogPath             :: !(Last FilePath)
+    , pccLogConfig           :: !(Last FilePath)
+    , pccDBPath              :: !(Last FilePath)
+    , pccApplicationLockFile :: !(Last FilePath)
+    , pccCore                :: !(Last PartialCore)
+    , pccNTP                 :: !(Last NTP)
+    , pccUpdate              :: !(Last Update)
+    , pccTXP                 :: !(Last TXP)
+    , pccSSC                 :: !(Last SSC)
+    , pccDLG                 :: !(Last DLG)
+    , pccBlock               :: !(Last Block)
+    , pccNode                :: !(Last Node)
+    , pccTLS                 :: !(Last TLS)
+    , pccWallet              :: !(Last Wallet)
+    } deriving (Eq, Show)
+
 -- | Do we require network magic or not?
 -- Network magic allows the differentiation from mainnet and testnet.
 data RequireNetworkMagic
@@ -70,28 +88,34 @@ data RequireNetworkMagic
 
 -- | Core configuration.
 data Core = Core
-    { coGenesis              :: !(Last Genesis)
+    { coGenesis              :: !Genesis
     -- ^ Genesis information
-    , coRequiresNetworkMagic :: !(Last RequireNetworkMagic)
+    , coRequiresNetworkMagic :: !RequireNetworkMagic
     -- ^ Do we require the network byte indicator for mainnet, testnet or staging?
-    , coDBSerializeVersion   :: !(Last Integer)
+    , coDBSerializeVersion   :: !Integer
     -- ^ Versioning for values in node's DB.
     } deriving (Eq, Show, Generic)
 
-instance Semigroup Core where
+data PartialCore = PartialCore
+    { pcoGenesis              :: !(Last PartialGenesis)
+    , pcoRequiresNetworkMagic :: !(Last RequireNetworkMagic)
+    , pcoDBSerializeVersion   :: !(Last Integer)
+    } deriving (Eq, Show, Generic)
+
+instance Semigroup PartialCore where
     core1 <> core2 =
-        Core
-            { coGenesis                 = coGenesis core1 <> coGenesis core2
-            , coRequiresNetworkMagic    = coRequiresNetworkMagic core1 <> coRequiresNetworkMagic core2
-            , coDBSerializeVersion      = coDBSerializeVersion core1 <> coDBSerializeVersion core2
+        PartialCore
+            { pcoGenesis                 = pcoGenesis core1 <> pcoGenesis core2
+            , pcoRequiresNetworkMagic    = pcoRequiresNetworkMagic core1 <> pcoRequiresNetworkMagic core2
+            , pcoDBSerializeVersion      = pcoDBSerializeVersion core1 <> pcoDBSerializeVersion core2
             }
 
-instance Monoid Core where
+instance Monoid PartialCore where
     mempty =
-        Core
-            { coGenesis                 = mempty
-            , coRequiresNetworkMagic    = mempty
-            , coDBSerializeVersion      = mempty
+        PartialCore
+            { pcoGenesis                 = mempty
+            , pcoRequiresNetworkMagic    = mempty
+            , pcoDBSerializeVersion      = mempty
             }
 
 -- | The genesis section.
@@ -109,20 +133,26 @@ data Genesis = Genesis
     , gePrevBlockHash   :: !Text
     } deriving (Eq, Show, Generic)
 
-instance Semigroup Genesis where
+data PartialGenesis = PartialGenesis
+    { pgeSrc            :: !(Last FilePath)
+    , pgeGenesisHash    :: !(Last Text)
+    , pgePrevBlockHash  :: !(Last Text)
+    } deriving (Eq, Show, Generic)
+
+instance Semigroup PartialGenesis where
     genesis1 <> genesis2 =
-        Genesis
-            { geSrc             = geSrc genesis1 <> geSrc genesis2
-            , geGenesisHash     = geGenesisHash genesis1 <> geGenesisHash genesis2
-            , gePrevBlockHash   = gePrevBlockHash genesis1 <> gePrevBlockHash genesis2
+        PartialGenesis
+            { pgeSrc             = pgeSrc genesis1 <> pgeSrc genesis2
+            , pgeGenesisHash     = pgeGenesisHash genesis1 <> pgeGenesisHash genesis2
+            , pgePrevBlockHash   = pgePrevBlockHash genesis1 <> pgePrevBlockHash genesis2
             }
 
-instance Monoid Genesis where
+instance Monoid PartialGenesis where
     mempty =
-        Genesis
-            { geSrc             = mempty
-            , geGenesisHash     = mempty
-            , gePrevBlockHash   = mempty
+        PartialGenesis
+            { pgeSrc             = mempty
+            , pgeGenesisHash     = mempty
+            , pgePrevBlockHash   = mempty
             }
 
 data Spec = Spec

--- a/src/Cardano/Shell/Lib.hs
+++ b/src/Cardano/Shell/Lib.hs
@@ -35,7 +35,7 @@ import           Cardano.Shell.Types (ApplicationEnvironment (..),
                                       CardanoEnvironment, CardanoFeature (..),
                                       initializeCardanoEnvironment)
 
-import           Cardano.Shell.Constants.Types (CardanoConfiguration (..))
+import           Cardano.Shell.Constants.Types (CardanoConfiguration (..), PartialCardanoConfiguration (..))
 
 import           Cardano.Shell.Presets (mainnetConfiguration)
 
@@ -48,6 +48,7 @@ data GeneralException
     | FileNotFoundException FilePath
     | ApplicationAlreadyRunningException
     | LockFileDoesNotExist FilePath
+    | ConfigurationError Text
     deriving (Eq)
 
 instance Exception GeneralException
@@ -57,6 +58,7 @@ instance Buildable GeneralException where
     build (FileNotFoundException filePath)      = bprint ("File not found on path '"%stext%"'.") (strConv Lenient filePath)
     build ApplicationAlreadyRunningException    = bprint "Application is already running. Please shut down the application first."
     build (LockFileDoesNotExist filePath)       = bprint ("Lock file not found on path '"%stext%"'.") (strConv Lenient filePath)
+    build (ConfigurationError etext)            = bprint ("Configuration error: "%stext%".") etext
 
 -- | Instance so we can see helpful error messages when something goes wrong.
 instance Show GeneralException where
@@ -147,7 +149,7 @@ runCardanoApplicationWithFeatures _ cardanoFeatures cardanoApplication = do
         pure ()
 
 
-type AllFeaturesInitFunction = CardanoConfiguration -> CardanoEnvironment -> IO [CardanoFeature]
+type AllFeaturesInitFunction = PartialCardanoConfiguration -> CardanoEnvironment -> IO [CardanoFeature]
 
 
 -- | The wrapper for the application providing modules.

--- a/src/Cardano/Shell/Presets.hs
+++ b/src/Cardano/Shell/Presets.hs
@@ -6,9 +6,11 @@ module Cardano.Shell.Presets
 import           Cardano.Prelude
 
 import           Cardano.Shell.Constants.Types (Block (..),
-                                                CardanoConfiguration (..),
-                                                Certificate (..), Core (..),
-                                                DLG (..), Genesis (..),
+                                                PartialCardanoConfiguration (..),
+                                                Certificate (..),
+                                                PartialCore (..),
+                                                DLG (..),
+                                                PartialGenesis (..),
                                                 LastKnownBlockVersion (..),
                                                 NTP (..), Node (..),
                                                 RequireNetworkMagic (..),
@@ -20,25 +22,25 @@ import           Cardano.Shell.Constants.Types (Block (..),
 -- Cardano Mainnet Configuration
 --------------------------------------------------------------------------------
 
-mainnetConfiguration :: CardanoConfiguration
+mainnetConfiguration :: PartialCardanoConfiguration
 mainnetConfiguration =
-  CardanoConfiguration
-    { ccLogPath             = "./logs/"
-    , ccLogConfig           = "./configuration/log-configuration.yaml"
-    , ccDBPath              = "./db/"
-    , ccApplicationLockFile = ""
-    , ccCore =
-        pure Core
-          { coGenesis =
-              pure Genesis
-                { geSrc             = "mainnet-genesis.json"
-                , geGenesisHash     = "89d9b5a5b8ddc8d7e5a6795e9774d97faf1efea59b2caf7eaf9f8c5b32059df4"
-                , gePrevBlockHash   = "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
+  PartialCardanoConfiguration
+    { pccLogPath             = pure "./logs/"
+    , pccLogConfig           = pure "./configuration/log-configuration.yaml"
+    , pccDBPath              = pure "./db/"
+    , pccApplicationLockFile = pure ""
+    , pccCore =
+        pure PartialCore
+          { pcoGenesis =
+              pure PartialGenesis
+                { pgeSrc             = pure "mainnet-genesis.json"
+                , pgeGenesisHash     = pure "89d9b5a5b8ddc8d7e5a6795e9774d97faf1efea59b2caf7eaf9f8c5b32059df4"
+                , pgePrevBlockHash   = pure "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
                 }
-          , coRequiresNetworkMagic = Last $ Just RequireNetworkMagic
-          , coDBSerializeVersion   = Last Nothing
+          , pcoRequiresNetworkMagic = pure RequireNetworkMagic
+          , pcoDBSerializeVersion   = mempty
           }
-    , ccNTP =
+    , pccNTP = pure
         NTP
           { ntpResponseTimeout = 30000000
           , ntpPollDelay       = 1800000000
@@ -48,7 +50,7 @@ mainnetConfiguration =
               , "3.pool.ntp.org"
               ]
           }
-    , ccUpdate =
+    , pccUpdate = pure
         Update
           { upApplicationName       = "cardano-sl"
           , upApplicationVersion    = 1
@@ -59,22 +61,22 @@ mainnetConfiguration =
                 , lkbvAlt   = 0
                 }
                                                }
-    , ccTXP =
+    , pccTXP = pure
         TXP
           { txpMemPoolLimitTx = 200
           , txpAssetLockedSrcAddress = []
           }
-    , ccSSC =
+    , pccSSC = pure
         SSC
           { sscMPCSendInterval               = 100
           , sscMdNoCommitmentsEpochThreshold = 3
           , sscNoReportNoSecretsForEpoch1    = True
           }
-    , ccDLG =
+    , pccDLG = pure
         DLG { dlgCacheParam          = 500
             , dlgMessageCacheTimeout = 30
             }
-    , ccBlock =
+    , pccBlock = pure
         Block
           { blNetworkDiameter        = 18
           , blRecoveryHeadersMessage = 2200
@@ -86,7 +88,7 @@ mainnetConfiguration =
           , blCriticalForkThreshold  = 3
           , blFixedTimeCQ            = 3600
           }
-    , ccNode =
+    , pccNode = pure
         Node
           { noNetworkConnectionTimeout     = 15000
           , noConversationEstablishTimeout = 30000
@@ -96,7 +98,7 @@ mainnetConfiguration =
           , noWalletTxCreationDisabled     = False
           , noExplorerExtendedApi          = False
           }
-    , ccTLS =
+    , pccTLS = pure
         TLS
           { tlsCA =
               Certificate
@@ -124,7 +126,7 @@ mainnetConfiguration =
                 , certAltDNS       = []
                 }
                                             }
-    , ccWallet =
+    , pccWallet = pure
         Wallet
           { waThrottle =
               SetThrottle
@@ -140,26 +142,26 @@ mainnetConfiguration =
 -- Cardano Dev Configuration
 --------------------------------------------------------------------------------
 
-devConfiguration :: CardanoConfiguration
+devConfiguration :: PartialCardanoConfiguration
 devConfiguration =
-  CardanoConfiguration
-    { ccLogPath             = "./logs/"
-    , ccDBPath              = "./db/"
-    , ccLogConfig           = "./log-config.yaml"
-    , ccApplicationLockFile = ""
-    , ccCore     =
-      pure Core
-        { coGenesis  =
-          pure Genesis
-            { geSrc             = "testnet-genesis.json"
-            , geGenesisHash     = "7f141ea26e189c9cb09e2473f6499561011d5d3c90dd642fde859ce02282a3ae"
-            , gePrevBlockHash   = "b7f76950bc4866423538ab7764fc1c7020b24a5f717a5bee3109ff2796567214"
+  PartialCardanoConfiguration
+    { pccLogPath             = pure "./logs/"
+    , pccDBPath              = pure "./db/"
+    , pccLogConfig           = pure "./log-config.yaml"
+    , pccApplicationLockFile = pure ""
+    , pccCore                = pure
+      PartialCore
+        { pcoGenesis  =
+          pure PartialGenesis
+            { pgeSrc             = pure "testnet-genesis.json"
+            , pgeGenesisHash     = pure "7f141ea26e189c9cb09e2473f6499561011d5d3c90dd642fde859ce02282a3ae"
+            , pgePrevBlockHash   = pure "b7f76950bc4866423538ab7764fc1c7020b24a5f717a5bee3109ff2796567214"
             }
-        , coRequiresNetworkMagic = Last $ Just RequireNetworkMagic
-        , coDBSerializeVersion   = Last Nothing
+        , pcoRequiresNetworkMagic = pure RequireNetworkMagic
+        , pcoDBSerializeVersion   = mempty
         }
-    , ccNTP =
-        NTP
+    , pccNTP                 = pure
+         NTP
           { ntpResponseTimeout = 30000000
           , ntpPollDelay       = 1800000000
           , ntpServers         =
@@ -168,7 +170,7 @@ devConfiguration =
             , "3.pool.ntp.org"
             ]
           }
-    , ccUpdate =
+    , pccUpdate              = pure
         Update
           { upApplicationName       = "cardano-sl"
           , upApplicationVersion    = 0
@@ -179,23 +181,23 @@ devConfiguration =
               , lkbvAlt   = 0
               }
                                                }
-    , ccTXP =
+    , pccTXP                 = pure
         TXP
           { txpMemPoolLimitTx = 200
           , txpAssetLockedSrcAddress = []
           }
-    , ccSSC =
+    , pccSSC                 = pure
         SSC
           { sscMPCSendInterval = 10
           , sscMdNoCommitmentsEpochThreshold = 3
           , sscNoReportNoSecretsForEpoch1    = False
           }
-    , ccDLG =
+    , pccDLG                 = pure
         DLG
           { dlgCacheParam          = 500
           , dlgMessageCacheTimeout = 30
           }
-    , ccBlock =
+    , pccBlock               = pure
         Block
           { blNetworkDiameter        = 3
           , blRecoveryHeadersMessage = 20
@@ -207,7 +209,7 @@ devConfiguration =
           , blCriticalForkThreshold  = 2
           , blFixedTimeCQ            = 10
           }
-    , ccNode =
+    , pccNode                = pure
         Node
           { noNetworkConnectionTimeout     = 15000
           , noConversationEstablishTimeout = 30000
@@ -217,7 +219,7 @@ devConfiguration =
           , noWalletTxCreationDisabled     = False
           , noExplorerExtendedApi          = False
           }
-    , ccTLS =
+    , pccTLS                 = pure
         TLS
           { tlsCA =
               Certificate
@@ -246,7 +248,7 @@ devConfiguration =
                 , certAltDNS       = []
                 }
           }
-    , ccWallet =
+    , pccWallet              = pure
         Wallet
           { waThrottle =  SetThrottle
             { thEnabled = False


### PR DESCRIPTION
Take the next step in the partial-options-monoid implementation:

1. Finalisation functions that handle partiality
2. Cover `CardanoConfiguration`
3. Reverts to having unchanged `CardanoConfiguration` and `Core` types, using the `Last` type only in the `Partial`* variants.

Part of https://github.com/input-output-hk/cardano-shell/issues/210