### PR TITLE
[GH-242] Add missing CLI options to shell.

### DIFF
--- a/app/Cardano/Shell/Features/Networking.hs
+++ b/app/Cardano/Shell/Features/Networking.hs
@@ -12,8 +12,7 @@ import           Cardano.Shell.Features.Logging (LoggingLayer (..))
 import           Cardano.Shell.Types (CardanoEnvironment, CardanoFeature (..),
                                       CardanoFeatureInit (..))
 
-import           Cardano.Shell.Constants.Types (CardanoConfiguration (..),
-                                                Core (..), Wallet (..))
+import           Cardano.Shell.Constants.Types (CardanoConfiguration (..))
 --------------------------------------------------------------------------------
 -- Networking feature
 --------------------------------------------------------------------------------
@@ -75,9 +74,6 @@ createNetworkingFeature loggingLayer cardanoEnvironment cardanoConfiguration = d
     -- We don't know where the user wants to fetch the additional configuration from, it could be from
     -- the filesystem, so we give him the most flexible/powerful context, @IO@.
     networkingConfiguration <-  pure "THIS IS AN EXAMPLE OF A CONFIGURATION!"
-
-    putTextLn $ "The DB version - "         <> (show $ coDBSerializeVersion $ ccCore cardanoConfiguration)
-    putTextLn $ "The Wallet Throttle - "    <> (show $ thRate $ ccWallet cardanoConfiguration)
 
     -- we construct the layer
     networkingLayer         <- (featureInit networkingCardanoFeatureInit) cardanoEnvironment loggingLayer cardanoConfiguration networkingConfiguration

--- a/app/Cardano/Shell/Features/Networking.hs
+++ b/app/Cardano/Shell/Features/Networking.hs
@@ -76,8 +76,8 @@ createNetworkingFeature loggingLayer cardanoEnvironment cardanoConfiguration = d
     -- the filesystem, so we give him the most flexible/powerful context, @IO@.
     networkingConfiguration <-  pure "THIS IS AN EXAMPLE OF A CONFIGURATION!"
 
-    putTextLn $ "The DB version - " <> (show $ coDBSerializeVersion $ ccCore cardanoConfiguration)
-    putTextLn $ "The Wallet Throttle - " <> (show $ thRate $ ccWallet cardanoConfiguration)
+    putTextLn $ "The DB version - "         <> (show $ coDBSerializeVersion $ ccCore cardanoConfiguration)
+    putTextLn $ "The Wallet Throttle - "    <> (show $ thRate $ ccWallet cardanoConfiguration)
 
     -- we construct the layer
     networkingLayer         <- (featureInit networkingCardanoFeatureInit) cardanoEnvironment loggingLayer cardanoConfiguration networkingConfiguration

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,6 +4,10 @@ module Main (main) where
 
 import           Cardano.Prelude
 
+import           Text.Show.Pretty (ppShow)
+
+import           Options.Applicative
+
 import           Cardano.Shell.Features.Logging (LoggingCLIArguments,
                                                  LoggingLayer (..),
                                                  createLoggingFeature,
@@ -16,9 +20,6 @@ import           Cardano.Shell.Constants.PartialTypes (PartialCardanoConfigurati
 import           Cardano.Shell.Lib
 import           Cardano.Shell.Presets (mainnetConfiguration)
 import           Cardano.Shell.Types
-
-import           Options.Applicative
-
 
 -- | The product type of all command line arguments.
 -- All here being - from all the features.
@@ -91,13 +92,13 @@ initializeAllFeatures partialConfig cardanoEnvironment = do
     let cardanoConfiguration'   = partialConfig <> cardanoConfigurationCLI
 
     putTextLn "************************************************"
-    putTextLn "Cardano configurationn"
+    putTextLn "Cardano configuration"
     putTextLn "************************************************"
-    putTextLn $ show partialConfig
+    putTextLn . toS . ppShow $ partialConfig
     putTextLn "------------------------------------------------"
-    putTextLn $ show cardanoConfigurationCLI
+    putTextLn . toS . ppShow $ cardanoConfigurationCLI
     putTextLn "------------------------------------------------"
-    putTextLn $ show cardanoConfiguration'
+    putTextLn . toS . ppShow $ cardanoConfiguration'
     putTextLn "------------------------------------------------"
 
     -- Finalize the configuration and if something is missing, just throw error.

--- a/cardano-shell.cabal
+++ b/cardano-shell.cabal
@@ -97,6 +97,7 @@ executable cardano-shell-exe
     , cardano-shell
     , cardano-prelude
     -- util
+    , pretty-show >=1.9.5
     , optparse-applicative
     , safe-exceptions
     , stm

--- a/nix/.stack.nix/cardano-shell.nix
+++ b/nix/.stack.nix/cardano-shell.nix
@@ -46,6 +46,7 @@
             (hsPkgs.base)
             (hsPkgs.cardano-shell)
             (hsPkgs.cardano-prelude)
+            (hsPkgs.pretty-show)
             (hsPkgs.optparse-applicative)
             (hsPkgs.safe-exceptions)
             (hsPkgs.stm)

--- a/src/Cardano/Shell/Configuration/Lib.hs
+++ b/src/Cardano/Shell/Configuration/Lib.hs
@@ -34,7 +34,6 @@ import           Cardano.Shell.Constants.PartialTypes (PartialBlock (..), Partia
                                                        PartialLastKnownBlockVersion (..),
                                                        PartialNTP (..),
                                                        PartialNode (..),
-                                                       PartialSSC (..),
                                                        PartialTLS (..),
                                                        PartialTXP (..),
                                                        PartialUpdate (..),
@@ -44,8 +43,8 @@ import           Cardano.Shell.Constants.Types (Block (..),
                                                 Certificate (..), Core (..),
                                                 DLG (..),
                                                 LastKnownBlockVersion (..),
-                                                NTP (..), Node (..), SSC (..),
-                                                TLS (..), TXP (..), Update (..),
+                                                NTP (..), Node (..), TLS (..),
+                                                TXP (..), Update (..),
                                                 Wallet (..))
 
 -- | Converting a @Last@ to an @Either@
@@ -73,14 +72,10 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
     ccNTP                    <- finaliseNTP pccNTP
     ccUpdate                 <- finaliseUpdate pccUpdate
     ccTXP                    <- finaliseTXP pccTXP
-    ccSSC                    <- finaliseSSC pccSSC
     ccDLG                    <- finaliseDLG pccDLG
     ccBlock                  <- finaliseBlock pccBlock
-
     ccNode                   <- finaliseNode pccNode
-
     ccTLS                    <- finaliseTLS pccTLS
-
     ccWallet                 <- finaliseWallet pccWallet
 
     pure CardanoConfiguration{..}
@@ -95,11 +90,8 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
         coGenesisHash                   <- lastToEither "Unspecified coGenesisHash"
                                             pcoGenesisHash
 
-        coNodeId                        <- lastToEither "Unspecified coNodeId"
-                                            pcoNodeId
-
-        coNumCoreNodes                  <- lastToEither "Unspecified coNumCoreNodes"
-                                            pcoNumCoreNodes
+        let coNodeId                    = getLast pcoNodeId
+        let coNumCoreNodes              = getLast pcoNumCoreNodes
 
         coNodeProtocol                  <- lastToEither "Unspecified coNodeProtocol"
                                             pcoNodeProtocol
@@ -109,9 +101,6 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
 
         coRequiresNetworkMagic          <- lastToEither "Unspecified coRequiresNetworkMagic"
                                             pcoRequiresNetworkMagic
-
-        coDBSerializeVersion            <- lastToEither "Unspecified coDBSerializeVersion"
-                                            pcoDBSerializeVersion
 
         let coPBftSigThd                = getLast pcoPBftSigThd
 
@@ -124,9 +113,6 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
 
         txpMemPoolLimitTx           <- lastToEither "Unspecified txpMemPoolLimitTx"
                                         ptxpMemPoolLimitTx
-
-        txpAssetLockedSrcAddress    <- lastToEither "Unspecified txpAssetLockedSrcAddress"
-                                        ptxpAssetLockedSrcAddress
 
         pure TXP{..}
 
@@ -148,23 +134,6 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
             lkbvAlt    <- lastToEither "Unspecified lkbvAlt"       plkbvAlt
 
             pure LastKnownBlockVersion{..}
-
-
-    -- | Finalize the @PartialNTP@, convert to @NTP@.
-    finaliseSSC :: PartialSSC -> Either Text SSC
-    finaliseSSC PartialSSC{..} = do
-
-        sscMPCSendInterval                 <- lastToEither "Unspecified sscMPCSendInterval"
-                                                psscMPCSendInterval
-
-        sscMdNoCommitmentsEpochThreshold   <- lastToEither "Unspecified sscMdNoCommitmentsEpochThreshold"
-                                                psscMdNoCommitmentsEpochThreshold
-
-        sscNoReportNoSecretsForEpoch1      <- lastToEither "Unspecified sscNoReportNoSecretsForEpoch1"
-                                                psscNoReportNoSecretsForEpoch1
-
-        pure SSC{..}
-
 
     -- | Finalize the @PartialNTP@, convert to @NTP@.
     finaliseNTP :: PartialNTP -> Either Text NTP
@@ -197,15 +166,6 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
 
         noPendingTxResubmissionPeriod   <- lastToEither "Unspecified noPendingTxResubmissionPeriod"
                                             pnoPendingTxResubmissionPeriod
-
-        noWalletProductionApi           <- lastToEither "Unspecified noWalletProductionApi"
-                                            pnoWalletProductionApi
-
-        noWalletTxCreationDisabled      <- lastToEither "Unspecified noWalletTxCreationDisabled"
-                                            pnoWalletTxCreationDisabled
-
-        noExplorerExtendedApi           <- lastToEither "Unspecified noExplorerExtendedApi"
-                                            pnoExplorerExtendedApi
 
         pure Node{..}
 

--- a/src/Cardano/Shell/Configuration/Lib.hs
+++ b/src/Cardano/Shell/Configuration/Lib.hs
@@ -114,6 +114,9 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
         txpMemPoolLimitTx           <- lastToEither "Unspecified txpMemPoolLimitTx"
                                         ptxpMemPoolLimitTx
 
+        txpAssetLockedSrcAddress    <- lastToEither "Unspecified txpAssetLockedSrcAddress"
+                                        ptxpAssetLockedSrcAddress
+
         pure TXP{..}
 
     -- | Finalize the @PartialUpdate@, convert to @Update@.

--- a/src/Cardano/Shell/Configuration/Lib.hs
+++ b/src/Cardano/Shell/Configuration/Lib.hs
@@ -158,14 +158,8 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
         noNetworkConnectionTimeout      <- lastToEither "Unspecified noNetworkConnectionTimeout"
                                             pnoNetworkConnectionTimeout
 
-        noConversationEstablishTimeout  <- lastToEither "Unspecified noConversationEstablishTimeout"
-                                            pnoConversationEstablishTimeout
-
-        noBlockRetrievalQueueSize       <- lastToEither "Unspecified noBlockRetrievalQueueSize"
-                                            pnoBlockRetrievalQueueSize
-
-        noPendingTxResubmissionPeriod   <- lastToEither "Unspecified noPendingTxResubmissionPeriod"
-                                            pnoPendingTxResubmissionPeriod
+        noHandshakeTimeout              <- lastToEither "Unspecified noHandshakeTimeout"
+                                            pnoHandshakeTimeout
 
         pure Node{..}
 

--- a/src/Cardano/Shell/Configuration/Lib.hs
+++ b/src/Cardano/Shell/Configuration/Lib.hs
@@ -89,16 +89,31 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
     finaliseCore :: PartialCore -> Either Text Core
     finaliseCore PartialCore{..} = do
 
-        coGenesisFile               <- lastToEither "Unspecified coGenesisFile"             pcoGenesisFile
-        coGenesisHash               <- lastToEither "Unspecified coGenesisHash"             pcoGenesisHash
+        coGenesisFile                   <- lastToEither "Unspecified coGenesisFile"
+                                            pcoGenesisFile
 
-        coStaticKeySigningKeyFile   <- lastToEither "Unspecified coStaticKeySigningKeyFile" pcoStaticKeySigningKeyFile
-        coStaticKeyDlgCertFile      <- lastToEither "Unspecified coStaticKeyDlgCertFile"    pcoStaticKeyDlgCertFile
+        coGenesisHash                   <- lastToEither "Unspecified coGenesisHash"
+                                            pcoGenesisHash
 
-        coRequiresNetworkMagic      <- lastToEither "Unspecified coRequiresNetworkMagic"    pcoRequiresNetworkMagic
-        coDBSerializeVersion        <- lastToEither "Unspecified coDBSerializeVersion"      pcoDBSerializeVersion
+        coNodeId                        <- lastToEither "Unspecified coNodeId"
+                                            pcoNodeId
 
-        coPBftSigThd                <- lastToEither "Unspecified coPBftSigThd"              pcoPBftSigThd
+        coNumCoreNodes                  <- lastToEither "Unspecified coNumCoreNodes"
+                                            pcoNumCoreNodes
+
+        coNodeProtocol                  <- lastToEither "Unspecified coNodeProtocol"
+                                            pcoNodeProtocol
+
+        let coStaticKeySigningKeyFile   = getLast pcoStaticKeySigningKeyFile
+        let coStaticKeyDlgCertFile      = getLast pcoStaticKeyDlgCertFile
+
+        coRequiresNetworkMagic          <- lastToEither "Unspecified coRequiresNetworkMagic"
+                                            pcoRequiresNetworkMagic
+
+        coDBSerializeVersion            <- lastToEither "Unspecified coDBSerializeVersion"
+                                            pcoDBSerializeVersion
+
+        let coPBftSigThd                = getLast pcoPBftSigThd
 
         pure Core{..}
 
@@ -107,8 +122,11 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
     finaliseTXP :: PartialTXP -> Either Text TXP
     finaliseTXP PartialTXP{..} = do
 
-        txpMemPoolLimitTx           <- lastToEither "Unspecified txpMemPoolLimitTx"         ptxpMemPoolLimitTx
-        txpAssetLockedSrcAddress    <- lastToEither "Unspecified txpAssetLockedSrcAddress"  ptxpAssetLockedSrcAddress
+        txpMemPoolLimitTx           <- lastToEither "Unspecified txpMemPoolLimitTx"
+                                        ptxpMemPoolLimitTx
+
+        txpAssetLockedSrcAddress    <- lastToEither "Unspecified txpAssetLockedSrcAddress"
+                                        ptxpAssetLockedSrcAddress
 
         pure TXP{..}
 
@@ -116,8 +134,8 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
     finaliseUpdate :: PartialUpdate -> Either Text Update
     finaliseUpdate PartialUpdate{..} = do
 
-        upApplicationName          <- lastToEither "Unspecified upApplicationName"         pupApplicationName
-        upApplicationVersion       <- lastToEither "Unspecified upApplicationVersion"      pupApplicationVersion
+        upApplicationName          <- lastToEither "Unspecified upApplicationName"      pupApplicationName
+        upApplicationVersion       <- lastToEither "Unspecified upApplicationVersion"   pupApplicationVersion
         upLastKnownBlockVersion    <- finaliseLastKnownBlockVersion pupLastKnownBlockVersion
 
         pure Update{..}
@@ -161,6 +179,12 @@ finaliseCardanoConfiguration PartialCardanoConfiguration{..} = do
     -- | Finalize the @PartialNode@, convert to @Node@.
     finaliseNode :: PartialNode -> Either Text Node
     finaliseNode PartialNode{..} = do
+
+        noSystemStartTime               <- lastToEither "Unspecified noSystemStartTime"
+                                            pnoSystemStartTime
+
+        noSlotLength                    <- lastToEither "Unspecified noSlotLength"
+                                            pnoSlotLength
 
         noNetworkConnectionTimeout      <- lastToEither "Unspecified noNetworkConnectionTimeout"
                                             pnoNetworkConnectionTimeout

--- a/src/Cardano/Shell/Constants/CLI.hs
+++ b/src/Cardano/Shell/Constants/CLI.hs
@@ -12,8 +12,6 @@ module Cardano.Shell.Constants.CLI
     , configTXPCLIParser
     -- * Update
     , configUpdateCLIParser
-    -- * SSC
-    , configSSCCLIParser
     -- * DLG
     , configDLGCLIParser
     -- * Block
@@ -43,24 +41,27 @@ lastOption parser = Last <$> optional parser
 lastAutoOption :: Read a => Mod OptionFields a -> Parser (Last a)
 lastAutoOption args = lastOption (option auto args)
 
+-- | Specific @Last@ @Int@ option.
 lastIntOption :: Mod OptionFields Int -> Parser (Last Int)
 lastIntOption = lastAutoOption
 
+-- | Specific @Last@ @Integer@ option.
 lastIntegerOption :: Mod OptionFields Integer -> Parser (Last Integer)
 lastIntegerOption = lastAutoOption
 
+-- | Specific @Last@ @Double@ option.
 lastDoubleOption :: Mod OptionFields Double -> Parser (Last Double)
 lastDoubleOption = lastAutoOption
 
+-- | Specific @Last@ @Bool@ option.
 lastBoolOption :: Mod OptionFields Bool -> Parser (Last Bool)
 lastBoolOption = lastAutoOption
 
-lastWordOption :: Mod OptionFields Word -> Parser (Last Word)
-lastWordOption = lastAutoOption
-
+-- | Specific @Last@ @[Text]@ option.
 lastTextListOption :: Mod OptionFields [Text] -> Parser (Last [Text])
 lastTextListOption = lastAutoOption
 
+-- | Specific @Last@ @IsString a@ option.
 lastStrOption :: IsString a => Mod OptionFields a -> Parser (Last a)
 lastStrOption args = Last <$> optional (strOption args)
 
@@ -95,7 +96,6 @@ configCardanoConfigurationCLIParser =
         <*> configNTPCLIParser
         <*> configUpdateCLIParser
         <*> configTXPCLIParser
-        <*> configSSCCLIParser
         <*> configDLGCLIParser
         <*> configBlockCLIParser
         <*> configNodeCLIParser
@@ -141,7 +141,6 @@ configCoreCLIParser = PartialCore
           <> help "Path to the delegation certificate."
            )
     <*> lastOption configNetworkMagicCLIParser
-    <*> lastOption configDBVersionCLIParser
     <*> lastDoubleOption
            ( long "pbft-signature-threshold"
           <> metavar "DOUBLE"
@@ -162,15 +161,6 @@ configCoreCLIParser = PartialCore
         noRequiredNetworkMagicParser = flag' NoRequireNetworkMagic
             ( long "no-require-network-magic"
            <> help "Doesn not require network magic"
-            )
-
-    -- | The parser for the DB version.
-    configDBVersionCLIParser :: Parser Integer
-    configDBVersionCLIParser =
-        option auto
-            ( long "db-version"
-           <> metavar "VERSION"
-           <> help "The version of the DB."
             )
 
     -- | The parser for the type of the node procotol.
@@ -232,22 +222,6 @@ configNodeCLIParser =
           <> metavar "DELAY"
           <> help "Minimal delay between pending transactions resubmission."
            )
-        <*> lastBoolOption
-           ( long "wallet-production-api"
-          <> metavar "BOOL"
-          <> help "Whether hazard wallet endpoint should be disabled."
-           )
-        <*> lastBoolOption
-           ( long "block-pending-transactions"
-          <> metavar "BOOL"
-          <> help "Disallow transaction creation or re-submission of pending transactions by the wallet."
-           )
-        -- TODO(KS): Pretty sure we don't need this one.
-        <*> lastBoolOption
-           ( long "explorer-extended-api"
-          <> metavar "BOOL"
-          <> help "Enable explorer extended API for fetching more."
-           )
 
 --------------------------------------------------------------------------------
 -- TXP
@@ -261,11 +235,6 @@ configTXPCLIParser =
            ( long "txp-mempool-queue-size"
           <> metavar "NUMBER"
           <> help "Limit on the number of transactions that can be stored in the mem pool."
-           )
-        <*> lastTextListOption
-           ( long "txp-asset-locked-addresses"
-          <> metavar "ADRESS-LIST"
-          <> help "Set of source address which are asset-locked. Transactions which use these addresses as transaction inputs will be silently dropped."
            )
 
 --------------------------------------------------------------------------------
@@ -308,30 +277,6 @@ configUpdateCLIParser =
               <> metavar "INT"
               <> help "Last known block version alternative."
                )
-
---------------------------------------------------------------------------------
--- SSC
---------------------------------------------------------------------------------
-
--- | SSC CLI parser.
-configSSCCLIParser :: Parser PartialSSC
-configSSCCLIParser =
-    PartialSSC
-        <$> lastWordOption
-           ( long "ssc-mpc-send-interval"
-          <> metavar "INTERVAL"
-          <> help "Length of interval for sending MPC message."
-           )
-        <*> lastIntOption
-           ( long "ssc-no-commitments-epoch-threshold"
-          <> metavar "THRESHOLD"
-          <> help "Threshold of epochs for malicious activity detection."
-           )
-        <*> lastBoolOption
-           ( long "ssc-no-report-no-secrets-for-fepoch"
-          <> metavar "SERVER-LIST"
-          <> help "Don't print “SSC couldn't compute seed” for the first epoch."
-           )
 
 --------------------------------------------------------------------------------
 -- NTP

--- a/src/Cardano/Shell/Constants/CLI.hs
+++ b/src/Cardano/Shell/Constants/CLI.hs
@@ -46,6 +46,9 @@ lastAutoOption args = lastOption (option auto args)
 lastIntOption :: Mod OptionFields Int -> Parser (Last Int)
 lastIntOption = lastAutoOption
 
+lastIntegerOption :: Mod OptionFields Integer -> Parser (Last Integer)
+lastIntegerOption = lastAutoOption
+
 lastDoubleOption :: Mod OptionFields Double -> Parser (Last Double)
 lastDoubleOption = lastAutoOption
 
@@ -69,10 +72,10 @@ configCardanoConfigurationCLIParser :: Parser PartialCardanoConfiguration
 configCardanoConfigurationCLIParser =
     PartialCardanoConfiguration
         <$> lastStrOption
-             ( long "log-path"
-            <> metavar "FILEPATH"
-            <> help "The filepath to the log file."
-             )
+            ( long "log-path"
+           <> metavar "FILEPATH"
+           <> help "The filepath to the log file."
+            )
         <*> lastStrOption
             ( long "log-config"
             <> metavar "FILEPATH"
@@ -116,26 +119,34 @@ configCoreCLIParser = PartialCore
           <> metavar "GENESIS-HASH"
           <> help "The genesis hash value."
            )
-    <*> (Just <<$>> lastStrOption
+    <*> lastIntOption
+           ( long "node-id"
+          <> metavar "INT"
+          <> help "Core node ID, the unique number of the node."
+           )
+    <*> lastIntOption
+           ( long "num-cores"
+          <> metavar "INT"
+          <> help "The number of the core nodes."
+           )
+    <*> lastOption parseNodeProtocol
+    <*> lastStrOption
            ( long "signing-key"
           <> metavar "FILEPATH"
           <> help "Path to the signing key."
            )
-        )
-    <*> (Just <<$>> lastStrOption
+    <*> lastStrOption
            ( long "delegation-certificate"
           <> metavar "FILEPATH"
           <> help "Path to the delegation certificate."
            )
-        )
     <*> lastOption configNetworkMagicCLIParser
     <*> lastOption configDBVersionCLIParser
-    <*> (Just <<$>> lastDoubleOption
+    <*> lastDoubleOption
            ( long "pbft-signature-threshold"
           <> metavar "DOUBLE"
           <> help "The PBFT signature threshold."
            )
-        )
   where
     -- | Parser for the network magic options.
     configNetworkMagicCLIParser :: Parser RequireNetworkMagic
@@ -162,6 +173,27 @@ configCoreCLIParser = PartialCore
            <> help "The version of the DB."
             )
 
+    -- | The parser for the type of the node procotol.
+    parseNodeProtocol :: Parser NodeProtocol
+    parseNodeProtocol = asum
+        [ flag' BFTProtocol $ mconcat
+            [ long "bft"
+            , help "Use the BFT consensus algorithm"
+            ]
+        , flag' PraosProtocol $ mconcat
+            [ long "praos"
+            , help "Use the Praos consensus algorithm"
+            ]
+        , flag' MockPBFTProtocol $ mconcat
+            [ long "mock-pbft"
+            , help "Use the Permissive BFT consensus algorithm using a mock ledger"
+            ]
+        , flag' RealPBFTProtocol $ mconcat
+            [ long "real-pbft"
+            , help "Use the Permissive BFT consensus algorithm using the real ledger"
+            ]
+        ]
+
 --------------------------------------------------------------------------------
 -- Node
 --------------------------------------------------------------------------------
@@ -170,7 +202,17 @@ configCoreCLIParser = PartialCore
 configNodeCLIParser :: Parser PartialNode
 configNodeCLIParser =
     PartialNode
-        <$> lastIntOption
+        <$> lastIntegerOption
+           ( long "system-start"
+          <> metavar "INTEGER"
+          <> help "Node system start time."
+           )
+        <*> lastIntegerOption
+           ( long "slot-length"
+          <> metavar "INTEGER"
+          <> help "Slot length time."
+           )
+        <*> lastIntOption
            ( long "network-connection-timeout"
           <> metavar "TIMEOUT"
           <> help "Network connection timeout in milliseconds."

--- a/src/Cardano/Shell/Constants/CLI.hs
+++ b/src/Cardano/Shell/Constants/CLI.hs
@@ -226,6 +226,12 @@ configTXPCLIParser =
           <> metavar "NUMBER"
           <> help "Limit on the number of transactions that can be stored in the mem pool."
            )
+        <*> lastTextListOption
+           ( long "txp-asset-locked-addresses"
+          <> metavar "ADRESS-LIST"
+          <> help "Set of source address which are asset-locked. Transactions which use\
+              \these addresses as transaction inputs will be silently dropped."
+           )
 
 --------------------------------------------------------------------------------
 -- Update

--- a/src/Cardano/Shell/Constants/CLI.hs
+++ b/src/Cardano/Shell/Constants/CLI.hs
@@ -208,19 +208,9 @@ configNodeCLIParser =
           <> help "Network connection timeout in milliseconds."
            )
         <*> lastIntOption
-           ( long "conversation-acknowledgement-timeout"
+           ( long "handshake-timeout"
           <> metavar "TIMEOUT"
-          <> help "Conversation acknowledgement timeout in milliseconds."
-           )
-        <*> lastIntOption
-           ( long "block-queue-capacity"
-          <> metavar "CAPACITY"
-          <> help "Block retrieval queue capacity."
-           )
-        <*> lastIntOption
-           ( long "transaction-resubmission-delay"
-          <> metavar "DELAY"
-          <> help "Minimal delay between pending transactions resubmission."
+          <> help "Protocol acknowledgement timeout in milliseconds."
            )
 
 --------------------------------------------------------------------------------

--- a/src/Cardano/Shell/Constants/PartialTypes.hs
+++ b/src/Cardano/Shell/Constants/PartialTypes.hs
@@ -18,6 +18,7 @@ module Cardano.Shell.Constants.PartialTypes
     , PartialWallet (..)
     -- * re-exports
     , RequireNetworkMagic (..)
+    , NodeProtocol (..)
     ) where
 
 import           Cardano.Prelude
@@ -50,32 +51,42 @@ data PartialCardanoConfiguration = PartialCardanoConfiguration
 data PartialCore = PartialCore
     { pcoGenesisFile                :: !(Last FilePath)
     , pcoGenesisHash                :: !(Last Text)
-    , pcoStaticKeySigningKeyFile    :: !(Last (Maybe FilePath))
-    , pcoStaticKeyDlgCertFile       :: !(Last (Maybe FilePath))
+    , pcoNodeId                     :: !(Last Int)
+    -- ^ Core node ID, the number of the node.
+    , pcoNumCoreNodes               :: !(Last Int)
+    -- ^ The number of the core nodes.
+    , pcoNodeProtocol               :: !(Last NodeProtocol)
+    -- ^ The type of protocol run on the node.
+    , pcoStaticKeySigningKeyFile    :: !(Last FilePath)
+    , pcoStaticKeyDlgCertFile       :: !(Last FilePath)
     , pcoRequiresNetworkMagic       :: !(Last RequireNetworkMagic)
     , pcoDBSerializeVersion         :: !(Last Integer)
-    , pcoPBftSigThd                 :: !(Last (Maybe Double))
+    , pcoPBftSigThd                 :: !(Last Double)
     } deriving (Eq, Show, Generic)
     deriving Semigroup via GenericSemigroup PartialCore
     deriving Monoid    via GenericMonoid PartialCore
 
 --- | Top-level Cardano SL node configuration
 data PartialNode = PartialNode
-    { pnoNetworkConnectionTimeout     :: !(Last Int)
-      -- ^ Network connection timeout in milliseconds.
-    , pnoConversationEstablishTimeout :: !(Last Int)
-      -- ^ Conversation acknowledgement timeout in milliseconds.
-    , pnoBlockRetrievalQueueSize      :: !(Last Int)
-      -- ^ Block retrieval queue capacity.
-    , pnoPendingTxResubmissionPeriod  :: !(Last Int)
-      -- ^ Minimal delay between pending transactions resubmission.
-    , pnoWalletProductionApi          :: !(Last Bool)
-      -- ^ Whether hazard wallet endpoint should be disabled.
-    , pnoWalletTxCreationDisabled     :: !(Last Bool)
-      -- ^ Disallow transaction creation or re-submission of
-      -- pending transactions by the wallet.
-    , pnoExplorerExtendedApi          :: !(Last Bool)
-      -- ^ Enable explorer extended API for fetching more.
+    { pnoSystemStartTime                :: !(Last Integer)
+    -- ^ Node system start time.
+    , pnoSlotLength                     :: !(Last Integer)
+    -- ^ Slot length time.
+    , pnoNetworkConnectionTimeout       :: !(Last Int)
+    -- ^ Network connection timeout in milliseconds.
+    , pnoConversationEstablishTimeout   :: !(Last Int)
+    -- ^ Conversation acknowledgement timeout in milliseconds.
+    , pnoBlockRetrievalQueueSize        :: !(Last Int)
+    -- ^ Block retrieval queue capacity.
+    , pnoPendingTxResubmissionPeriod    :: !(Last Int)
+    -- ^ Minimal delay between pending transactions resubmission.
+    , pnoWalletProductionApi            :: !(Last Bool)
+    -- ^ Whether hazard wallet endpoint should be disabled.
+    , pnoWalletTxCreationDisabled       :: !(Last Bool)
+    -- ^ Disallow transaction creation or re-submission of
+    -- pending transactions by the wallet.
+    , pnoExplorerExtendedApi            :: !(Last Bool)
+    -- ^ Enable explorer extended API for fetching more.
     } deriving (Eq, Show, Generic)
     deriving Semigroup via GenericSemigroup PartialNode
     deriving Monoid    via GenericMonoid PartialNode

--- a/src/Cardano/Shell/Constants/PartialTypes.hs
+++ b/src/Cardano/Shell/Constants/PartialTypes.hs
@@ -71,12 +71,8 @@ data PartialNode = PartialNode
     -- ^ Slot length time.
     , pnoNetworkConnectionTimeout       :: !(Last Int)
     -- ^ Network connection timeout in milliseconds.
-    , pnoConversationEstablishTimeout   :: !(Last Int)
-    -- ^ Conversation acknowledgement timeout in milliseconds.
-    , pnoBlockRetrievalQueueSize        :: !(Last Int)
-    -- ^ Block retrieval queue capacity.
-    , pnoPendingTxResubmissionPeriod    :: !(Last Int)
-    -- ^ Minimal delay between pending transactions resubmission.
+    , pnoHandshakeTimeout               :: !(Last Int)
+    -- ^ Protocol acknowledgement timeout in milliseconds.
     } deriving (Eq, Show, Generic)
     deriving Semigroup via GenericSemigroup PartialNode
     deriving Monoid    via GenericMonoid PartialNode

--- a/src/Cardano/Shell/Constants/PartialTypes.hs
+++ b/src/Cardano/Shell/Constants/PartialTypes.hs
@@ -9,7 +9,6 @@ module Cardano.Shell.Constants.PartialTypes
     , PartialNTP (..)
     , PartialUpdate (..)
     , PartialLastKnownBlockVersion (..)
-    , PartialSSC (..)
     , PartialTXP (..)
     , PartialDLG (..)
     , PartialBlock (..)
@@ -37,7 +36,6 @@ data PartialCardanoConfiguration = PartialCardanoConfiguration
     , pccNTP                 :: !PartialNTP
     , pccUpdate              :: !PartialUpdate
     , pccTXP                 :: !PartialTXP
-    , pccSSC                 :: !PartialSSC
     , pccDLG                 :: !PartialDLG
     , pccBlock               :: !PartialBlock
     , pccNode                :: !PartialNode
@@ -60,7 +58,6 @@ data PartialCore = PartialCore
     , pcoStaticKeySigningKeyFile    :: !(Last FilePath)
     , pcoStaticKeyDlgCertFile       :: !(Last FilePath)
     , pcoRequiresNetworkMagic       :: !(Last RequireNetworkMagic)
-    , pcoDBSerializeVersion         :: !(Last Integer)
     , pcoPBftSigThd                 :: !(Last Double)
     } deriving (Eq, Show, Generic)
     deriving Semigroup via GenericSemigroup PartialCore
@@ -80,13 +77,6 @@ data PartialNode = PartialNode
     -- ^ Block retrieval queue capacity.
     , pnoPendingTxResubmissionPeriod    :: !(Last Int)
     -- ^ Minimal delay between pending transactions resubmission.
-    , pnoWalletProductionApi            :: !(Last Bool)
-    -- ^ Whether hazard wallet endpoint should be disabled.
-    , pnoWalletTxCreationDisabled       :: !(Last Bool)
-    -- ^ Disallow transaction creation or re-submission of
-    -- pending transactions by the wallet.
-    , pnoExplorerExtendedApi            :: !(Last Bool)
-    -- ^ Enable explorer extended API for fetching more.
     } deriving (Eq, Show, Generic)
     deriving Semigroup via GenericSemigroup PartialNode
     deriving Monoid    via GenericMonoid PartialNode
@@ -107,9 +97,6 @@ data PartialNTP = PartialNTP
 data PartialTXP = PartialTXP
     { ptxpMemPoolLimitTx        :: !(Last Int)
     -- ^ Limit on the number of transactions that can be stored in the mem pool.
-    , ptxpAssetLockedSrcAddress :: !(Last [Text])
-    -- ^ Set of source address which are asset-locked. Transactions which
-    -- use these addresses as transaction inputs will be silently dropped.
     } deriving (Eq, Show, Generic)
     deriving Semigroup via GenericSemigroup PartialTXP
     deriving Monoid    via GenericMonoid PartialTXP
@@ -137,18 +124,6 @@ data PartialLastKnownBlockVersion = PartialLastKnownBlockVersion
     } deriving (Eq, Show, Generic)
     deriving Semigroup via GenericSemigroup PartialLastKnownBlockVersion
     deriving Monoid    via GenericMonoid PartialLastKnownBlockVersion
-
--- | Partial @SSC@ configuration.
-data PartialSSC = PartialSSC
-    { psscMPCSendInterval               :: !(Last Word)
-      -- ^ Length of interval for sending MPC message
-    , psscMdNoCommitmentsEpochThreshold :: !(Last Int)
-      -- ^ Threshold of epochs for malicious activity detection
-    , psscNoReportNoSecretsForEpoch1    :: !(Last Bool)
-      -- ^ Don't print “SSC couldn't compute seed” for the first epoch.
-    } deriving (Eq, Show, Generic)
-    deriving Semigroup via GenericSemigroup PartialSSC
-    deriving Monoid    via GenericMonoid PartialSSC
 
 -- | Partial @DLG@ configuration.
 data PartialDLG = PartialDLG

--- a/src/Cardano/Shell/Constants/PartialTypes.hs
+++ b/src/Cardano/Shell/Constants/PartialTypes.hs
@@ -93,6 +93,9 @@ data PartialNTP = PartialNTP
 data PartialTXP = PartialTXP
     { ptxpMemPoolLimitTx        :: !(Last Int)
     -- ^ Limit on the number of transactions that can be stored in the mem pool.
+    , ptxpAssetLockedSrcAddress :: !(Last [Text])
+    -- ^ Set of source address which are asset-locked. Transactions which
+    -- use these addresses as transaction inputs will be silently dropped.
     } deriving (Eq, Show, Generic)
     deriving Semigroup via GenericSemigroup PartialTXP
     deriving Monoid    via GenericMonoid PartialTXP

--- a/src/Cardano/Shell/Constants/Types.hs
+++ b/src/Cardano/Shell/Constants/Types.hs
@@ -264,12 +264,8 @@ data Node = Node
     -- ^ Slot length time.
     , noNetworkConnectionTimeout        :: !Int
     -- ^ Network connection timeout in milliseconds.
-    , noConversationEstablishTimeout    :: !Int
-    -- ^ Conversation acknowledgement timeout in milliseconds.
-    , noBlockRetrievalQueueSize         :: !Int
-    -- ^ Block retrieval queue capacity.
-    , noPendingTxResubmissionPeriod     :: !Int
-    -- ^ Minimal delay between pending transactions resubmission.
+    , noHandshakeTimeout                :: !Int
+    -- ^ Protocol acknowledgement timeout in milliseconds.
     } deriving (Eq, Show)
 
 data TLS = TLS

--- a/src/Cardano/Shell/Constants/Types.hs
+++ b/src/Cardano/Shell/Constants/Types.hs
@@ -21,7 +21,6 @@ module Cardano.Shell.Constants.Types
     , NTP (..)
     , Update (..)
     , TXP (..)
-    , SSC (..)
     , DLG (..)
     , Block (..)
     , Node (..)
@@ -55,7 +54,6 @@ data CardanoConfiguration = CardanoConfiguration
     , ccNTP                 :: !NTP
     , ccUpdate              :: !Update
     , ccTXP                 :: !TXP
-    , ccSSC                 :: !SSC
     , ccDLG                 :: !DLG
     , ccBlock               :: !Block
     , ccNode                :: !Node
@@ -91,9 +89,9 @@ data Core = Core
     -- ^ Genesis source file JSON.
     , coGenesisHash                 :: !Text
     -- ^ Genesis previous block hash.
-    , coNodeId                      :: !Int
+    , coNodeId                      :: !(Maybe Int)
     -- ^ Core node ID, the number of the node.
-    , coNumCoreNodes                :: !Int
+    , coNumCoreNodes                :: !(Maybe Int)
     -- ^ The number of the core nodes.
     , coNodeProtocol                :: !NodeProtocol
     -- ^ The type of protocol run on the node.
@@ -103,8 +101,6 @@ data Core = Core
     -- ^ Static key delegation certificate.
     , coRequiresNetworkMagic        :: !RequireNetworkMagic
     -- ^ Do we require the network byte indicator for mainnet, testnet or staging?
-    , coDBSerializeVersion          :: !Integer
-    -- ^ Versioning for values in node's DB.
     , coPBftSigThd                  :: !(Maybe Double)
     -- ^ PBFT signature threshold system parameters
     } deriving (Eq, Show, Generic)
@@ -226,21 +222,9 @@ data LastKnownBlockVersion = LastKnownBlockVersion
     -- ^ Last known block version alternative.
     } deriving (Eq, Show)
 
-data SSC = SSC
-    { sscMPCSendInterval               :: !Word
-      -- ^ Length of interval for sending MPC message
-    , sscMdNoCommitmentsEpochThreshold :: !Int
-      -- ^ Threshold of epochs for malicious activity detection
-    , sscNoReportNoSecretsForEpoch1    :: !Bool
-      -- ^ Don't print “SSC couldn't compute seed” for the first epoch.
-    } deriving (Eq, Show)
-
 data TXP = TXP
     { txpMemPoolLimitTx        :: !Int
       -- ^ Limit on the number of transactions that can be stored in the mem pool.
-    , txpAssetLockedSrcAddress :: ![Text]
-      -- ^ Set of source address which are asset-locked. Transactions which
-      -- use these addresses as transaction inputs will be silently dropped.
     } deriving (Eq, Show)
 
 data DLG = DLG
@@ -286,13 +270,6 @@ data Node = Node
     -- ^ Block retrieval queue capacity.
     , noPendingTxResubmissionPeriod     :: !Int
     -- ^ Minimal delay between pending transactions resubmission.
-    , noWalletProductionApi             :: !Bool
-    -- ^ Whether hazard wallet endpoint should be disabled.
-    , noWalletTxCreationDisabled        :: !Bool
-    -- ^ Disallow transaction creation or re-submission of
-    -- pending transactions by the wallet.
-    , noExplorerExtendedApi             :: !Bool
-    -- ^ Enable explorer extended API for fetching more.
     } deriving (Eq, Show)
 
 data TLS = TLS

--- a/src/Cardano/Shell/Constants/Types.hs
+++ b/src/Cardano/Shell/Constants/Types.hs
@@ -224,7 +224,10 @@ data LastKnownBlockVersion = LastKnownBlockVersion
 
 data TXP = TXP
     { txpMemPoolLimitTx        :: !Int
-      -- ^ Limit on the number of transactions that can be stored in the mem pool.
+    -- ^ Limit on the number of transactions that can be stored in the mem pool.
+    , txpAssetLockedSrcAddress :: ![Text]
+    -- ^ Set of source address which are asset-locked. Transactions which
+    -- use these addresses as transaction inputs will be silently dropped.
     } deriving (Eq, Show)
 
 data DLG = DLG

--- a/src/Cardano/Shell/Constants/Types.hs
+++ b/src/Cardano/Shell/Constants/Types.hs
@@ -6,6 +6,7 @@ module Cardano.Shell.Constants.Types
     , Core (..)
     -- * specific for @Core@
     , RequireNetworkMagic (..)
+    , NodeProtocol (..)
     , Spec (..)
     , Initializer (..)
     -- * rest
@@ -69,6 +70,14 @@ data RequireNetworkMagic
     | NoRequireNetworkMagic
     deriving (Eq, Show, Generic)
 
+-- | The type of the protocol being run on the node.
+data NodeProtocol
+    = BFTProtocol
+    | PraosProtocol
+    | MockPBFTProtocol
+    | RealPBFTProtocol
+    deriving (Eq, Show, Generic)
+
 -- | Core configuration.
 -- For now, we only store the path to the genesis file(s) and their hash.
 -- The rest is in the hands of the modules/features that need to use it.
@@ -82,6 +91,12 @@ data Core = Core
     -- ^ Genesis source file JSON.
     , coGenesisHash                 :: !Text
     -- ^ Genesis previous block hash.
+    , coNodeId                      :: !Int
+    -- ^ Core node ID, the number of the node.
+    , coNumCoreNodes                :: !Int
+    -- ^ The number of the core nodes.
+    , coNodeProtocol                :: !NodeProtocol
+    -- ^ The type of protocol run on the node.
     , coStaticKeySigningKeyFile     :: !(Maybe FilePath)
     -- ^ Static key signing file.
     , coStaticKeyDlgCertFile        :: !(Maybe FilePath)
@@ -259,21 +274,25 @@ data Block = Block
 
 --- | Top-level Cardano SL node configuration
 data Node = Node
-    { noNetworkConnectionTimeout     :: !Int
-      -- ^ Network connection timeout in milliseconds.
-    , noConversationEstablishTimeout :: !Int
-      -- ^ Conversation acknowledgement timeout in milliseconds.
-    , noBlockRetrievalQueueSize      :: !Int
-      -- ^ Block retrieval queue capacity.
-    , noPendingTxResubmissionPeriod  :: !Int
-      -- ^ Minimal delay between pending transactions resubmission.
-    , noWalletProductionApi          :: !Bool
-      -- ^ Whether hazard wallet endpoint should be disabled.
-    , noWalletTxCreationDisabled     :: !Bool
-      -- ^ Disallow transaction creation or re-submission of
-      -- pending transactions by the wallet.
-    , noExplorerExtendedApi          :: !Bool
-      -- ^ Enable explorer extended API for fetching more.
+    { noSystemStartTime                 :: !Integer
+    -- ^ Node system start time.
+    , noSlotLength                      :: !Integer
+    -- ^ Slot length time.
+    , noNetworkConnectionTimeout        :: !Int
+    -- ^ Network connection timeout in milliseconds.
+    , noConversationEstablishTimeout    :: !Int
+    -- ^ Conversation acknowledgement timeout in milliseconds.
+    , noBlockRetrievalQueueSize         :: !Int
+    -- ^ Block retrieval queue capacity.
+    , noPendingTxResubmissionPeriod     :: !Int
+    -- ^ Minimal delay between pending transactions resubmission.
+    , noWalletProductionApi             :: !Bool
+    -- ^ Whether hazard wallet endpoint should be disabled.
+    , noWalletTxCreationDisabled        :: !Bool
+    -- ^ Disallow transaction creation or re-submission of
+    -- pending transactions by the wallet.
+    , noExplorerExtendedApi             :: !Bool
+    -- ^ Enable explorer extended API for fetching more.
     } deriving (Eq, Show)
 
 data TLS = TLS

--- a/src/Cardano/Shell/Presets.hs
+++ b/src/Cardano/Shell/Presets.hs
@@ -90,9 +90,7 @@ mainnetConfiguration =
             { pnoSystemStartTime                = mempty
             , pnoSlotLength                     = mempty
             , pnoNetworkConnectionTimeout       = pure 15000
-            , pnoConversationEstablishTimeout   = pure 30000
-            , pnoBlockRetrievalQueueSize        = pure 100
-            , pnoPendingTxResubmissionPeriod    = pure 7
+            , pnoHandshakeTimeout               = pure 30000
             }
     , pccTLS =
         PartialTLS
@@ -202,9 +200,7 @@ devConfiguration =
             { pnoSystemStartTime                = mempty
             , pnoSlotLength                     = mempty
             , pnoNetworkConnectionTimeout       = pure 15000
-            , pnoConversationEstablishTimeout   = pure 30000
-            , pnoBlockRetrievalQueueSize        = pure 100
-            , pnoPendingTxResubmissionPeriod    = pure 7
+            , pnoHandshakeTimeout               = pure 30000
             }
     , pccTLS =
         PartialTLS

--- a/src/Cardano/Shell/Presets.hs
+++ b/src/Cardano/Shell/Presets.hs
@@ -14,7 +14,6 @@ import           Cardano.Shell.Constants.PartialTypes (NodeProtocol (..),
                                                        PartialLastKnownBlockVersion (..),
                                                        PartialNTP (..),
                                                        PartialNode (..),
-                                                       PartialSSC (..),
                                                        PartialTLS (..),
                                                        PartialTXP (..),
                                                        PartialUpdate (..),
@@ -42,7 +41,6 @@ mainnetConfiguration =
           , pcoStaticKeySigningKeyFile  = mempty
           , pcoStaticKeyDlgCertFile     = mempty
           , pcoRequiresNetworkMagic     = pure RequireNetworkMagic
-          , pcoDBSerializeVersion       = pure 0
           , pcoPBftSigThd               = mempty
           }
     , pccNTP =
@@ -69,13 +67,6 @@ mainnetConfiguration =
     , pccTXP =
         PartialTXP
           { ptxpMemPoolLimitTx          = pure 200
-          , ptxpAssetLockedSrcAddress   = pure []
-          }
-    , pccSSC =
-        PartialSSC
-          { psscMPCSendInterval                 = pure 100
-          , psscMdNoCommitmentsEpochThreshold   = pure 3
-          , psscNoReportNoSecretsForEpoch1      = pure True
           }
     , pccDLG =
         PartialDLG
@@ -102,9 +93,6 @@ mainnetConfiguration =
             , pnoConversationEstablishTimeout   = pure 30000
             , pnoBlockRetrievalQueueSize        = pure 100
             , pnoPendingTxResubmissionPeriod    = pure 7
-            , pnoWalletProductionApi            = pure True
-            , pnoWalletTxCreationDisabled       = pure False
-            , pnoExplorerExtendedApi            = pure False
             }
     , pccTLS =
         PartialTLS
@@ -165,7 +153,6 @@ devConfiguration =
           , pcoStaticKeySigningKeyFile  = mempty
           , pcoStaticKeyDlgCertFile     = mempty
           , pcoRequiresNetworkMagic     = pure RequireNetworkMagic
-          , pcoDBSerializeVersion       = pure 0
           , pcoPBftSigThd               = mempty
           }
     , pccNTP =
@@ -192,14 +179,7 @@ devConfiguration =
     , pccTXP =
         PartialTXP
           { ptxpMemPoolLimitTx           = pure 200
-          , ptxpAssetLockedSrcAddress    = pure []
           }
-    , pccSSC =
-        PartialSSC
-            { psscMPCSendInterval               = pure 10
-            , psscMdNoCommitmentsEpochThreshold = pure 3
-            , psscNoReportNoSecretsForEpoch1    = pure False
-            }
     , pccDLG =
         PartialDLG
           { pdlgCacheParam              = pure 500
@@ -225,9 +205,6 @@ devConfiguration =
             , pnoConversationEstablishTimeout   = pure 30000
             , pnoBlockRetrievalQueueSize        = pure 100
             , pnoPendingTxResubmissionPeriod    = pure 7
-            , pnoWalletProductionApi            = pure False
-            , pnoWalletTxCreationDisabled       = pure False
-            , pnoExplorerExtendedApi            = pure False
             }
     , pccTLS =
         PartialTLS

--- a/src/Cardano/Shell/Presets.hs
+++ b/src/Cardano/Shell/Presets.hs
@@ -5,7 +5,9 @@ module Cardano.Shell.Presets
 
 import           Cardano.Prelude
 
-import           Cardano.Shell.Constants.PartialTypes (PartialBlock (..), PartialCardanoConfiguration (..),
+import           Cardano.Shell.Constants.PartialTypes (NodeProtocol (..),
+                                                       PartialBlock (..),
+                                                       PartialCardanoConfiguration (..),
                                                        PartialCertificate (..),
                                                        PartialCore (..),
                                                        PartialDLG (..),
@@ -34,11 +36,14 @@ mainnetConfiguration =
         PartialCore
           { pcoGenesisFile              = pure "mainnet-genesis.json"
           , pcoGenesisHash              = pure "89d9b5a5b8ddc8d7e5a6795e9774d97faf1efea59b2caf7eaf9f8c5b32059df4"
-          , pcoStaticKeySigningKeyFile  = pure Nothing
-          , pcoStaticKeyDlgCertFile     = pure Nothing
+          , pcoNodeId                   = mempty
+          , pcoNumCoreNodes             = mempty
+          , pcoNodeProtocol             = pure BFTProtocol
+          , pcoStaticKeySigningKeyFile  = mempty
+          , pcoStaticKeyDlgCertFile     = mempty
           , pcoRequiresNetworkMagic     = pure RequireNetworkMagic
           , pcoDBSerializeVersion       = pure 0
-          , pcoPBftSigThd               = pure Nothing
+          , pcoPBftSigThd               = mempty
           }
     , pccNTP =
         PartialNTP
@@ -91,14 +96,16 @@ mainnetConfiguration =
           }
     , pccNode =
         PartialNode
-          { pnoNetworkConnectionTimeout     = pure 15000
-          , pnoConversationEstablishTimeout = pure 30000
-          , pnoBlockRetrievalQueueSize      = pure 100
-          , pnoPendingTxResubmissionPeriod  = pure 7
-          , pnoWalletProductionApi          = pure True
-          , pnoWalletTxCreationDisabled     = pure False
-          , pnoExplorerExtendedApi          = pure False
-          }
+            { pnoSystemStartTime                = mempty
+            , pnoSlotLength                     = mempty
+            , pnoNetworkConnectionTimeout       = pure 15000
+            , pnoConversationEstablishTimeout   = pure 30000
+            , pnoBlockRetrievalQueueSize        = pure 100
+            , pnoPendingTxResubmissionPeriod    = pure 7
+            , pnoWalletProductionApi            = pure True
+            , pnoWalletTxCreationDisabled       = pure False
+            , pnoExplorerExtendedApi            = pure False
+            }
     , pccTLS =
         PartialTLS
           { ptlsCA =
@@ -152,11 +159,14 @@ devConfiguration =
         PartialCore
           { pcoGenesisFile              = pure "testnet-genesis.json"
           , pcoGenesisHash              = pure "7f141ea26e189c9cb09e2473f6499561011d5d3c90dd642fde859ce02282a3ae"
-          , pcoStaticKeySigningKeyFile  = pure Nothing
-          , pcoStaticKeyDlgCertFile     = pure Nothing
+          , pcoNodeId                   = mempty
+          , pcoNumCoreNodes             = mempty
+          , pcoNodeProtocol             = pure BFTProtocol
+          , pcoStaticKeySigningKeyFile  = mempty
+          , pcoStaticKeyDlgCertFile     = mempty
           , pcoRequiresNetworkMagic     = pure RequireNetworkMagic
           , pcoDBSerializeVersion       = pure 0
-          , pcoPBftSigThd               = pure Nothing
+          , pcoPBftSigThd               = mempty
           }
     , pccNTP =
         PartialNTP
@@ -209,14 +219,16 @@ devConfiguration =
           }
     , pccNode =
         PartialNode
-          { pnoNetworkConnectionTimeout     = pure 15000
-          , pnoConversationEstablishTimeout = pure 30000
-          , pnoBlockRetrievalQueueSize      = pure 100
-          , pnoPendingTxResubmissionPeriod  = pure 7
-          , pnoWalletProductionApi          = pure False
-          , pnoWalletTxCreationDisabled     = pure False
-          , pnoExplorerExtendedApi          = pure False
-          }
+            { pnoSystemStartTime                = mempty
+            , pnoSlotLength                     = mempty
+            , pnoNetworkConnectionTimeout       = pure 15000
+            , pnoConversationEstablishTimeout   = pure 30000
+            , pnoBlockRetrievalQueueSize        = pure 100
+            , pnoPendingTxResubmissionPeriod    = pure 7
+            , pnoWalletProductionApi            = pure False
+            , pnoWalletTxCreationDisabled       = pure False
+            , pnoExplorerExtendedApi            = pure False
+            }
     , pccTLS =
         PartialTLS
           { ptlsCA =

--- a/src/Cardano/Shell/Presets.hs
+++ b/src/Cardano/Shell/Presets.hs
@@ -66,8 +66,9 @@ mainnetConfiguration =
             }
     , pccTXP =
         PartialTXP
-          { ptxpMemPoolLimitTx          = pure 200
-          }
+            { ptxpMemPoolLimitTx          = pure 200
+            , ptxpAssetLockedSrcAddress   = pure []
+            }
     , pccDLG =
         PartialDLG
             { pdlgCacheParam          = pure 500
@@ -176,8 +177,9 @@ devConfiguration =
             }
     , pccTXP =
         PartialTXP
-          { ptxpMemPoolLimitTx           = pure 200
-          }
+            { ptxpMemPoolLimitTx        = pure 200
+            , ptxpAssetLockedSrcAddress = pure []
+            }
     , pccDLG =
         PartialDLG
           { pdlgCacheParam              = pure 500


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-shell/issues/242

Can be run using `stack build --fast -j12 --nix && stack exec cardano-shell-exe --nix -- --log-config configuration/log-configuration.yaml --system-start 123456789 --slot-length 123456789` for example.

Also fixing https://github.com/input-output-hk/cardano-shell/pull/234/files/51c691aff16e719c94f3ad85b938094d6cba9185#diff-6111c9baeacdb1421faa3d1f338c9728