### PR TITLE
fix mainnet genesis config hash

### DIFF
--- a/src/Cardano/Shell/Presets.hs
+++ b/src/Cardano/Shell/Presets.hs
@@ -33,7 +33,7 @@ mainnetConfiguration =
     , pccCore =
         PartialCore
           { pcoGenesisFile              = pure "mainnet-genesis.json"
-          , pcoGenesisHash              = pure "89d9b5a5b8ddc8d7e5a6795e9774d97faf1efea59b2caf7eaf9f8c5b32059df4"
+          , pcoGenesisHash              = pure "5f20df933584822601f9e3f8c024eb5eb252fe8cefb24d1317dc3d432e940ebb"
           , pcoStaticKeySigningKeyFile  = pure Nothing
           , pcoStaticKeyDlgCertFile     = pure Nothing
           , pcoRequiresNetworkMagic     = pure RequireNetworkMagic


### PR DESCRIPTION
It was the hash of the genesis _block_, but should be and now is the
hash of the canonical mainnet-genesis.json.