### PR TITLE
pcoPBftSigThd:  undo the Maybe

### DIFF
--- a/src/Cardano/Shell/Constants/CLI.hs
+++ b/src/Cardano/Shell/Constants/CLI.hs
@@ -130,7 +130,7 @@ configCoreCLIParser = PartialCore
         )
     <*> lastOption configNetworkMagicCLIParser
     <*> lastOption configDBVersionCLIParser
-    <*> (Just <<$>> lastDoubleOption
+    <*> (lastDoubleOption
            ( long "pbft-signature-threshold"
           <> metavar "DOUBLE"
           <> help "The PBFT signature threshold."

--- a/src/Cardano/Shell/Constants/PartialTypes.hs
+++ b/src/Cardano/Shell/Constants/PartialTypes.hs
@@ -54,7 +54,7 @@ data PartialCore = PartialCore
     , pcoStaticKeyDlgCertFile       :: !(Last (Maybe FilePath))
     , pcoRequiresNetworkMagic       :: !(Last RequireNetworkMagic)
     , pcoDBSerializeVersion         :: !(Last Integer)
-    , pcoPBftSigThd                 :: !(Last (Maybe Double))
+    , pcoPBftSigThd                 :: !(Last Double)
     } deriving (Eq, Show, Generic)
     deriving Semigroup via GenericSemigroup PartialCore
     deriving Monoid    via GenericMonoid PartialCore

--- a/src/Cardano/Shell/Constants/Types.hs
+++ b/src/Cardano/Shell/Constants/Types.hs
@@ -90,7 +90,7 @@ data Core = Core
     -- ^ Do we require the network byte indicator for mainnet, testnet or staging?
     , coDBSerializeVersion          :: !Integer
     -- ^ Versioning for values in node's DB.
-    , coPBftSigThd                  :: !(Maybe Double)
+    , coPBftSigThd                  :: !Double
     -- ^ PBFT signature threshold system parameters
     } deriving (Eq, Show, Generic)
 

--- a/src/Cardano/Shell/Presets.hs
+++ b/src/Cardano/Shell/Presets.hs
@@ -38,7 +38,7 @@ mainnetConfiguration =
           , pcoStaticKeyDlgCertFile     = pure Nothing
           , pcoRequiresNetworkMagic     = pure NoRequireNetworkMagic
           , pcoDBSerializeVersion       = pure 0
-          , pcoPBftSigThd               = pure Nothing
+          , pcoPBftSigThd               = pure 0.22
           }
     , pccNTP =
         PartialNTP
@@ -156,7 +156,7 @@ devConfiguration =
           , pcoStaticKeyDlgCertFile     = pure Nothing
           , pcoRequiresNetworkMagic     = pure RequireNetworkMagic
           , pcoDBSerializeVersion       = pure 0
-          , pcoPBftSigThd               = pure Nothing
+          , pcoPBftSigThd               = pure 0.22
           }
     , pccNTP =
         PartialNTP

--- a/test.nix
+++ b/test.nix
@@ -21,4 +21,8 @@ let
       touch $out
     '';
   };
-in builtins.listToAttrs (map mkTest [ "x86_64-linux" "x86_64-darwin" ])
+in builtins.listToAttrs (map mkTest [
+   "x86_64-linux"
+   # "x86_64-darwin" -- This has been (approximately since forever) causing intermittent failures, such as:
+   # https://iohk-nix-cache.s3-eu-central-1.amazonaws.com/log/8hl7r13yw4sbmyylcdpq2q3qj8d12jmk-test-ipc-x86_64-darwin.drv
+   ])


### PR DESCRIPTION
1. ~Undoes the thinko~ There's some controversy -- apparently the change was motivated -- see the discussion below.
2. ~Fixes~ disables the perpetual `test-ipc`/Darwin ~issue~ test, that looked like so:
```
dns.js:246
    this._handle = new ChannelWrap();
                   ^

Error: EFILE
    at new Resolver (dns.js:246:20)
    at dns.js:377:23
    at NativeModule.compile (bootstrap_node.js:600:7)
    at NativeModule.require (bootstrap_node.js:545:18)
    at net.js:45:13
    at NativeModule.compile (bootstrap_node.js:600:7)
    at NativeModule.require (bootstrap_node.js:545:18)
    at createWritableStdioStream (internal/process/stdio.js:163:17)
    at process.getStdout [as stdout] (internal/process/stdio.js:14:14)
    at console.js:249:38
builder for '/nix/store/8hl7r13yw4sbmyylcdpq2q3qj8d12jmk-test-ipc-x86_64-darwin.drv' failed with exit code 1
```