### PR TITLE
Extract code from Data.Text.Template

### DIFF
--- a/cardano-launcher/cardano-launcher.cabal
+++ b/cardano-launcher/cardano-launcher.cabal
@@ -90,6 +90,7 @@ test-suite cardano-launcher-test
       UpdaterSpec
     , LauncherSpec
     , LauncherSMSpec
+    , TemplateSpec
   hs-source-dirs:
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N

--- a/cardano-launcher/cardano-launcher.cabal
+++ b/cardano-launcher/cardano-launcher.cabal
@@ -22,6 +22,7 @@ library
       -- Update system
     , Cardano.Shell.Update.Lib
     , Cardano.Shell.Update.Types
+    , Cardano.Shell.Template
   hs-source-dirs:
       src
   build-depends:
@@ -37,6 +38,7 @@ library
     , turtle
     , yaml
     , time-units
+    , mtl
   if os(windows)
     build-depends:     Win32
 

--- a/cardano-launcher/src/Cardano/Shell/Template.hs
+++ b/cardano-launcher/src/Cardano/Shell/Template.hs
@@ -1,0 +1,236 @@
+{-| Borrowed from template package and modified it for our needs.
+
+The issue with original package is that it throws error when the first character
+of the identifier text is uppercase letter.
+
+-- @
+-- ${user} -- Ok
+-- ${uSER} -- Ok
+-- ${USER} -- @substituteA@ will throw error due to first character being uppercase
+-- letter.
+-- @
+
+This is a problem since in our case, the identifier text are env vars which are
+consisted by uppercase letters.
+
+To resolve this, we decided to borrow the code and modified it for our needs.
+-}
+
+module Cardano.Shell.Template
+    ( Template,
+      substituteA,
+    ) where
+
+import           Control.Applicative (Applicative (pure), (<$>))
+import           Control.Monad (liftM, liftM2, replicateM_)
+import           Control.Monad.State.Strict (State, evalState, get, put)
+import           Data.Char (isAlphaNum)
+import           Data.Function (on)
+import           Data.Maybe (fromJust, isJust)
+import           Data.Traversable (traverse)
+import           Prelude hiding (takeWhile)
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+
+-- -----------------------------------------------------------------------------
+
+-- | A representation of a 'Data.Text' template, supporting efficient
+-- rendering.
+newtype Template = Template [Frag]
+
+instance Eq Template where
+    (==) = (==) `on` showTemplate
+
+instance Show Template where
+    show = T.unpack . showTemplate
+
+-- | Show the template string.
+showTemplate :: Template -> T.Text
+showTemplate (Template fs) = T.concat $ map showFrag fs
+
+-- | A template fragment.
+data Frag = Lit {-# UNPACK #-} !T.Text | Var {-# UNPACK #-} !T.Text !Bool
+
+instance Show Frag where
+    show = T.unpack . showFrag
+
+showFrag :: Frag -> T.Text
+showFrag (Var s b)
+    | b          = T.concat [T.pack "${", s, T.pack "}"]
+    | otherwise  = T.concat [T.pack "$", s]
+showFrag (Lit s) = T.concatMap escape s
+    where escape '$' = T.pack "$$"
+          escape c   = T.singleton c
+
+-- | A mapping from placeholders in the template to values.
+type ContextA f = T.Text -> f T.Text
+
+-- -----------------------------------------------------------------------------
+-- Basic interface
+
+-- | Create a template from a template string.  A malformed template
+-- string will raise an 'error'.
+template :: T.Text -> Template
+template = templateFromFrags . runParser pFrags
+
+templateFromFrags :: [Frag] -> Template
+templateFromFrags = Template . combineLits
+
+combineLits :: [Frag] -> [Frag]
+combineLits [] = []
+combineLits xs =
+    let (lits,xs') = span isLit xs
+    in case lits of
+         []    -> gatherVars xs'
+         [lit] -> lit : gatherVars xs'
+         _     -> Lit (T.concat (map fromLit lits)) : gatherVars xs'
+  where
+    gatherVars [] = []
+    gatherVars ys =
+      let (vars,ys') = span isVar ys
+      in vars ++ combineLits ys'
+
+    isLit (Lit _) = True
+    isLit _       = False
+
+    isVar = not . isLit
+
+    fromLit (Lit v) = v
+    fromLit _       = undefined
+
+-- | Perform the template substitution, returning a new Text.
+renderA :: Applicative f => Template -> ContextA f -> f LT.Text
+renderA (Template frags) ctxFunc = LT.fromChunks <$> traverse renderFrag frags
+  where
+    renderFrag (Lit s)   = pure s
+    renderFrag (Var x _) = ctxFunc x
+
+-- | Perform the template substitution in the given 'Applicative',
+-- returning a new 'LT.Text'. Note that
+--
+-- > substituteA tmpl ctx == renderA (template tmpl) ctx
+substituteA :: Applicative f => T.Text -> ContextA f -> f LT.Text
+substituteA = renderA . template
+
+-- -----------------------------------------------------------------------------
+-- Template parser
+
+pFrags :: Parser [Frag]
+pFrags = do
+    c <- peek
+    case c of
+      Nothing  -> return []
+      Just '$' -> do c' <- peekSnd
+                     case c' of
+                       Just '$' -> do discard 2
+                                      continue (return $ Lit $ T.pack "$")
+                       _        -> continue pVar
+      _        -> continue pLit
+  where
+    continue x = liftM2 (:) x pFrags
+
+pVar :: Parser Frag
+pVar = do
+    discard 1
+    c <- peek
+    case c of
+      Just '{' -> do discard 1
+                     v <- pIdentifier
+                     c' <- peek
+                     case c' of
+                       Just '}' -> do discard 1
+                                      return $ Var v True
+                       _        -> liftM parseError pos
+      _        -> do v <- pIdentifier
+                     return $ Var v False
+
+pIdentifier :: Parser T.Text
+pIdentifier = do
+    m <- peek
+    if isJust m && isIdentifier0 (fromJust m)
+      then takeWhile isIdentifier1
+      else liftM parseError pos
+
+pLit :: Parser Frag
+pLit = do
+    s <- takeWhile (/= '$')
+    return $ Lit s
+
+isIdentifier0 :: Char -> Bool
+isIdentifier0 c = or [isAlphaNum c, c == '_'] -- Changed from `isLower`
+
+isIdentifier1 :: Char -> Bool
+isIdentifier1 c = or [isAlphaNum c, c `elem` ("_'" :: String)]
+
+parseError :: (Int, Int) -> a
+parseError = error . makeParseErrorMessage
+
+makeParseErrorMessage :: (Int, Int) -> String
+makeParseErrorMessage (row, col) =
+    "Invalid placeholder at " ++
+    "row " ++ show row ++ ", col " ++ show col
+
+-- -----------------------------------------------------------------------------
+-- Text parser
+
+-- | The parser state.
+data S = S {-# UNPACK #-} !T.Text  -- Remaining input
+           {-# UNPACK #-} !Int     -- Row
+           {-# UNPACK #-} !Int     -- Col
+
+type Parser = State S
+
+char :: Parser (Maybe Char)
+char = do
+    S s row col <- get
+    if T.null s
+      then return Nothing
+      else do c <- return $! T.head s
+              case c of
+                '\n' -> put $! S (T.tail s) (row + 1) 1
+                _    -> put $! S (T.tail s) row (col + 1)
+              return $ Just c
+
+peek :: Parser (Maybe Char)
+peek = do
+    s <- get
+    c <- char
+    put s
+    return c
+
+peekSnd :: Parser (Maybe Char)
+peekSnd = do
+    s <- get
+    _ <- char
+    c <- char
+    put s
+    return c
+
+takeWhile :: (Char -> Bool) -> Parser T.Text
+takeWhile p = do
+    S s row col <- get
+    case T.span p s of
+      (x, s') -> do
+                  let xlines = T.lines x
+                      row' = row + fromIntegral (length xlines - 1)
+                      col' = case xlines of
+                               []         -> col -- Empty selection
+                               [sameLine] -> T.length sameLine
+                                             -- Taken from this line
+                               _          -> T.length (last xlines)
+                                     -- Selection extends
+                                     -- to next line at least
+                  put $! S s' row' col'
+                  return x
+
+discard :: Int -> Parser ()
+discard n = replicateM_ n char
+
+pos :: Parser (Int, Int)
+pos = do
+    S _ row col <- get
+    return (row, col)
+
+runParser :: Parser a -> T.Text -> a
+runParser p s = evalState p $ S s 1 0

--- a/cardano-launcher/test/Spec.hs
+++ b/cardano-launcher/test/Spec.hs
@@ -3,6 +3,7 @@ module Main where
 import           Cardano.Prelude
 import           LauncherSMSpec (launcherSMSpec)
 import           LauncherSpec (launcherSpec)
+import           TemplateSpec (templateSpec)
 import           Test.Hspec (describe, hspec)
 import           UpdaterSpec (updaterSpec)
 
@@ -12,4 +13,5 @@ main = hspec $ do
     describe "Update spec" updaterSpec
     describe "Launcher spec" launcherSpec
     describe "LauncherSM spec" launcherSMSpec
+    describe "Template spec" templateSpec
 

--- a/cardano-launcher/test/TemplateSpec.hs
+++ b/cardano-launcher/test/TemplateSpec.hs
@@ -1,0 +1,56 @@
+{-| Test suite for Cardano.Shell.Template
+|-}
+
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module TemplateSpec
+    ( templateSpec
+    ) where
+
+import           Cardano.Prelude
+import           Data.Char (isAlphaNum)
+import           System.Environment (lookupEnv, setEnv, unsetEnv)
+import           System.IO.Error (userError)
+import           Test.Hspec (Spec)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import           Test.QuickCheck (Arbitrary (..), elements, listOf1, suchThat)
+import           Test.QuickCheck.Monadic (assert, monadicIO, run)
+
+import           Cardano.Shell.Template (substituteA)
+
+-- | Pair of environment variable and its value
+data EnvValue = EnvValue Text Text
+    deriving Show
+
+instance Arbitrary EnvValue where
+    arbitrary = EnvValue <$> randomEnv <*> randomVal
+      where
+        randomEnv = toS <$> listOf1 (elements $ ['A' .. 'Z'] <> ['0' .. '9'] <> ['_'])
+        randomVal = toS <$> listOf1 (arbitrary `suchThat` isAlphaNum)
+
+-- | Test that @substituteA@ will substitute @${var}@ with @value@ by looking up the
+-- environment variable
+templateSpec :: Spec
+templateSpec = modifyMaxSuccess (const 5000) $ do
+    prop "should be able to perform env var substitution" $ \(EnvValue var value)-> monadicIO $ do
+        shouldBeValue <- run $ do
+            setEnv (toS var) (toS value)
+            let text = "${" <> var <> "}"
+            subbed <- substituteA text substituteVar
+            return $ toStrict subbed
+        assert $ shouldBeValue == value
+    prop "should throw error if substitution fails" $ \(EnvValue var _value) -> monadicIO $ do
+        (eShouldFail :: Either IOException Text) <- run $ try $ do
+            unsetEnv (toS var)
+            let text = "${" <> var <> "}"
+            subbed <- substituteA text substituteVar
+            return $ toStrict subbed
+        assert $ isLeft eShouldFail
+  where
+    substituteVar :: Text -> IO Text
+    substituteVar var' = do
+        mValue <- lookupEnv (toS var')
+        case mValue of
+            Nothing -> ioError $ userError "Environment variable not found!"
+            Just value -> return $ toS value

--- a/nix/.stack.nix/cardano-launcher.nix
+++ b/nix/.stack.nix/cardano-launcher.nix
@@ -29,6 +29,7 @@
           (hsPkgs.turtle)
           (hsPkgs.yaml)
           (hsPkgs.time-units)
+          (hsPkgs.mtl)
           ] ++ (pkgs.lib).optional (system.isWindows) (hsPkgs.Win32);
         };
       exes = {


### PR DESCRIPTION
TODO: Resolve license issues. ~~Implement test cases~~.

This PR extract the code from `Data.Text.Temple` and modify so it can be used to perform env var substitution. 

https://github.com/input-output-hk/cardano-shell/issues/277