### PR TITLE
Supply context for the substitute environment variables

### DIFF
--- a/cardano-launcher/cardano-launcher.cabal
+++ b/cardano-launcher/cardano-launcher.cabal
@@ -92,6 +92,7 @@ test-suite cardano-launcher-test
     , LauncherSpec
     , LauncherSMSpec
     , TemplateSpec
+    , EnvironmentSpec
   hs-source-dirs:
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
@@ -109,6 +110,8 @@ test-suite cardano-launcher-test
     -- tests
     , hspec
     , yaml
+    , unordered-containers
+    , vector
   default-language:    Haskell2010
   default-extensions:  NoImplicitPrelude
                        OverloadedStrings

--- a/cardano-launcher/cardano-launcher.cabal
+++ b/cardano-launcher/cardano-launcher.cabal
@@ -23,6 +23,7 @@ library
     , Cardano.Shell.Update.Lib
     , Cardano.Shell.Update.Types
     , Cardano.Shell.Template
+    , Cardano.Shell.Environment
   hs-source-dirs:
       src
   build-depends:

--- a/cardano-launcher/src/Cardano/Shell/Environment.hs
+++ b/cardano-launcher/src/Cardano/Shell/Environment.hs
@@ -1,0 +1,68 @@
+{-| This is an example of how you can perform env var substitution
+}
+
+{-# LANGUAGE OverloadedStrings #-}
+
+module Cardano.Shell.Environment where
+
+import           Cardano.Prelude
+
+import           Cardano.Shell.Launcher (LauncherOptions)
+import           Cardano.Shell.Template (substituteA)
+import           Data.Aeson (Result (..), Value (..), fromJSON)
+import           Data.Yaml (decodeFileEither)
+import           System.Environment (lookupEnv, setEnv)
+
+-- This is a example of how you can decode yaml and perform env var substitution
+-- | Parse `yaml` file, perform env var substitution, return @LauncherOptions@
+-- if successful
+getLauncherOption' :: FilePath -> IO (Either SubstitutionError LauncherOptions)
+getLauncherOption' yamlPath = do
+  setEnv "XDG_DATA_HOME" "Foo"
+  setEnv "DAEDALUS_CONFIG" "Bar"
+  eSubstituted <- runExceptT $ do
+    decodedVal <- withExceptT (\e -> FailedToDecodeFile (show e)) $ 
+      ExceptT $ decodeFileEither yamlPath
+    substituted <- substituteEnvVars decodedVal
+    return substituted
+  case eSubstituted of
+    Left err -> return . Left $ err
+    Right sub -> case fromJSON sub of
+        Error _ -> return . Left $ FailedToParseLauncherOption
+        Success decoded -> return . Right $ decoded
+
+-- | Substitute envrionment variable with value of its name.
+--
+-- @
+-- runExceptT $ substituteEnvVarsText "Hello ${user}"
+-- Right "Hello hiroto"
+-- @
+substituteEnvVarsText :: Text -> ExceptT SubstitutionError IO Text
+substituteEnvVarsText text = toStrict <$> (substituteA text expandVariable)
+
+-- type ContextA f = Text -> f Text
+-- | Return the value of the environment variable @var@, or throw error if there
+-- is no such value.
+expandVariable :: Text -> ExceptT SubstitutionError IO Text
+expandVariable var = do
+    mValue <- liftIO $ lookupEnv (toS var)
+    case mValue of
+        Nothing    -> throwError $ FailedToLookupEnv var
+        Just value -> return $ toS value
+
+data SubstitutionError 
+  = FailedToLookupEnv Text
+  -- ^ Failed to lookup environment variable
+  | FailedToDecodeFile Text
+  -- ^ Failed to read/decode yaml file
+  | FailedToParseLauncherOption
+  -- ^ Failed to convert @Value@ into @LauncherOptions@
+  deriving Show
+
+-- | Given an Aeson 'Value', parse and substitute environment variables in all
+-- 'String' objects.
+substituteEnvVars :: Value -> ExceptT SubstitutionError IO Value
+substituteEnvVars (String text) = String <$> substituteEnvVarsText text
+substituteEnvVars (Array xs)    = Array  <$> traverse substituteEnvVars xs -- Traversing through array
+substituteEnvVars (Object o)    = Object <$> traverse substituteEnvVars o -- Traversing through object
+substituteEnvVars x             = return x

--- a/cardano-launcher/src/Cardano/Shell/Environment.hs
+++ b/cardano-launcher/src/Cardano/Shell/Environment.hs
@@ -1,9 +1,10 @@
-{-| This is an example of how you can perform env var substitution
-}
-
 {-# LANGUAGE OverloadedStrings #-}
 
-module Cardano.Shell.Environment where
+module Cardano.Shell.Environment
+  ( SubstitutionError(..)
+  , substituteEnvVars
+  , getLauncherOption'
+  ) where
 
 import           Cardano.Prelude
 
@@ -57,7 +58,7 @@ data SubstitutionError
   -- ^ Failed to read/decode yaml file
   | FailedToParseLauncherOption
   -- ^ Failed to convert @Value@ into @LauncherOptions@
-  deriving Show
+  deriving (Eq, Show)
 
 -- | Given an Aeson 'Value', parse and substitute environment variables in all
 -- 'String' objects.

--- a/cardano-launcher/test/EnvironmentSpec.hs
+++ b/cardano-launcher/test/EnvironmentSpec.hs
@@ -1,0 +1,108 @@
+{-| This module test that @substituteEnvVars@ works as expected
+|-}
+
+{-# LANGUAGE LambdaCase #-}
+
+module EnvironmentSpec
+    ( envSubstitutionSpec
+    ) where
+
+import           Cardano.Prelude
+import           Data.Char (isAlphaNum)
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Vector as V
+import qualified Data.Yaml as Y
+import           System.Environment (setEnv, unsetEnv)
+import           Test.Hspec (Spec)
+import           Test.Hspec.QuickCheck (modifyMaxSuccess, prop)
+import           Test.QuickCheck (Arbitrary (..), Gen, arbitraryASCIIChar,
+                                  arbitraryPrintableChar, elements, listOf,
+                                  listOf1, oneof, suchThat)
+import           Test.QuickCheck.Monadic (assert, monadicIO, run)
+
+import           Cardano.Shell.Environment (SubstitutionError (..),
+                                            substituteEnvVars)
+
+-- | Random Yaml object
+newtype RandomValue = RandomValue Y.Value
+    deriving Show
+
+-- | Pair of environment variable and its value
+data EnvValue = EnvValue !Text !Text
+    deriving Show
+
+instance Arbitrary RandomValue where
+    arbitrary = RandomValue <$> genValue
+        where
+            genValue :: Gen Y.Value
+            genValue = oneof
+                [ genObject
+                , genString
+                , genArray
+                ]
+
+            genString :: Gen Y.Value
+            genString = Y.String <$> genText
+
+            genObject :: Gen Y.Value
+            genObject = (Y.Object . HM.fromList) <$> listOf1 genKeyValue
+
+            genArray :: Gen Y.Value
+            genArray = (Y.Array . V.fromList) <$> listOf1 genString
+
+            genKeyValue :: Gen (Text, Y.Value)
+            genKeyValue = do
+                randomField <- genText
+                randomValue <- genString
+                return $ (randomField, randomValue)
+
+            genText :: Gen Text
+            genText = toS <$> listOf
+                (arbitraryPrintableChar `suchThat` (`notElem` ['$', '{', '}']))
+
+instance Arbitrary EnvValue where
+    arbitrary = EnvValue <$> randomVar <*> randomValue
+      where
+        randomVar = toS <$> listOf1 (elements $ ['A' .. 'Z'] <> ['0' .. '9'] <> ['_'])
+        randomValue = toS <$> listOf1 (arbitraryASCIIChar `suchThat` isAlphaNum)
+
+-- | Given a @EnvValue@, create a pair of yaml object, one with identifier text
+-- and other is expected result. This would be used to compare if substitution
+-- was done properly
+mkPairs :: EnvValue -> Y.Value -> (Y.Value, Y.Value)
+mkPairs (EnvValue var value) yamlObject =
+    let yamlObjectVar = appendText ("${" <> var <> "}") yamlObject
+        yamlObjectValue = appendText value yamlObject
+    in (yamlObjectVar, yamlObjectValue)
+  where
+    -- Append Text to the String value
+    appendText :: Text -> Y.Value -> Y.Value
+    appendText text = \case
+        Y.Object object -> Y.Object $ fmap (appendText text) object
+        Y.String string -> Y.String $ text <> string
+        Y.Array array -> Y.Array $ fmap (appendText text) array
+        others -> others
+
+envSubstitutionSpec :: Spec
+envSubstitutionSpec = modifyMaxSuccess (const 1000) $ do
+    prop "Should be able to perform env var substitution" $
+        \(envvalue@(EnvValue var value), (RandomValue yamlObject)) -> monadicIO $ do
+        let (sub, expectedResult) = mkPairs envvalue yamlObject
+        subbed <- run $ do
+            subbed <- withEnv (toS var) (toS value) (runExceptT (substituteEnvVars sub))
+            return subbed
+        assert $ subbed == (Right expectedResult)
+
+    prop "Should throw error due to env var missing" $
+        \(envvalue@(EnvValue var _value), (RandomValue yamlObject)) -> monadicIO $ do
+        let (sub, _expectedResult) = mkPairs envvalue yamlObject
+        eSubbed <- run $ do
+            unsetEnv (toS var)
+            runExceptT (substituteEnvVars sub)
+        assert $ eSubbed == (Left $ FailedToLookupEnv var)
+  where
+    withEnv :: Text -> Text -> IO a -> IO a
+    withEnv var value action = bracket
+        (setEnv (toS var) (toS value))
+        (const $ unsetEnv (toS var))
+        (const action)

--- a/cardano-launcher/test/Spec.hs
+++ b/cardano-launcher/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import           Cardano.Prelude
+import           EnvironmentSpec (envSubstitutionSpec)
 import           LauncherSMSpec (launcherSMSpec)
 import           LauncherSpec (launcherSpec)
 import           TemplateSpec (templateSpec)
@@ -14,4 +15,5 @@ main = hspec $ do
     describe "Launcher spec" launcherSpec
     describe "LauncherSM spec" launcherSMSpec
     describe "Template spec" templateSpec
+    describe "Env substitution spec" envSubstitutionSpec
 

--- a/nix/.stack.nix/cardano-launcher.nix
+++ b/nix/.stack.nix/cardano-launcher.nix
@@ -58,6 +58,8 @@
             (hsPkgs.tree-diff)
             (hsPkgs.hspec)
             (hsPkgs.yaml)
+            (hsPkgs.unordered-containers)
+            (hsPkgs.vector)
             ];
           };
         };


### PR DESCRIPTION
This PR introduces function `substituteEnvVars` which will traverse through yaml value and replace identifier text to actual value.
(e.g. if there was string value `${USER}`, it will look up environment variable name USER, then replace `${USER}` with that value)

https://github.com/input-output-hk/cardano-shell/issues/276
