### PR TITLE
Add cardano-launcher-test to hydra ci

### DIFF
--- a/cardano-launcher/src/Cardano/Shell/Launcher.hs
+++ b/cardano-launcher/src/Cardano/Shell/Launcher.hs
@@ -158,16 +158,16 @@ handleDaedalusExitCode
     -> IO DaedalusExitCode
 handleDaedalusExitCode runUpdaterFunction restartWalletFunction = isoTo <<$>> \case
     RunUpdate               -> runUpdate runUpdaterFunction >> runRestart restartWalletFunction
-    -- ^ Run the actual update, THEN restart launcher.
+    -- Run the actual update, THEN restart launcher.
     -- Do we maybe need to handle the update ExitCode as well?
     RestartInGPUSafeMode    -> runRestart restartWalletFunction
-    -- ^ Enable safe mode (GPU safe mode).
+    -- Enable safe mode (GPU safe mode).
     RestartInGPUNormalMode  -> runRestart restartWalletFunction
-    -- ^ Disable safe mode (GPU safe mode).
+    -- Disable safe mode (GPU safe mode).
     ExitCodeSuccess         -> return ExitSuccess
-    -- ^ All is well, exit "mucho bien".
+    -- All is well, exit "mucho bien".
     ExitCodeFailure ef      -> return $ ExitFailure ef
-    -- ^ Some other unexpected error popped up.
+    -- Some other unexpected error popped up.
 
 -- | Wallet runner type.
 -- I give you the path to the wallet, it's arguments and you execute it

--- a/release.nix
+++ b/release.nix
@@ -57,6 +57,7 @@ commonLib.nix-tools.release-nix {
     # tests
     jobs.tests.ipc.x86_64-linux
     # jobs.tests.ipc.x86_64-darwin # See comment in test.nix
+    jobs.nix-tools.tests.cardano-launcher.cardano-launcher-test.x86_64-linux
   ];
   extraBuilds = {
     tests.ipc = import ./test.nix;


### PR DESCRIPTION
This PR would enable the hydra CI to run test suites for the `cardano-launcher`
https://hydra.iohk.io/build/1153187

Notice job `nix-tools.tests.cardano-launcher.cardano-launcher-test.x86_64-linux` has been added as one of the jobs.
Before: https://hydra.iohk.io/build/1153098#tabs-constituents
After: https://hydra.iohk.io/build/1153190#tabs-constituents