### PR TITLE
Make it so that daedalus mock fails with ExitFailure 20

### DIFF
--- a/cardano-launcher/app/Mocks/Daedalus.hs
+++ b/cardano-launcher/app/Mocks/Daedalus.hs
@@ -3,6 +3,7 @@
 module Main where
 
 import Cardano.Prelude
+import System.Exit (exitWith)
 
 seconds :: Int
 seconds = 1000000
@@ -12,4 +13,4 @@ main = do
     putTextLn $ "Starting Daedalus"
     threadDelay $ 5 * seconds
     putText $ "Exiting for update"
-    return $ ExitFailure 20
+    exitWith $ ExitFailure 20


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-shell/issues/310

Use `exitWith` from `System.Exit` so that mock exits itself with `ExitFailure 20` which is what we want.