### PR TITLE
[GH-337] Create CLI support for tests for both launcher and the updater.

### DIFF
--- a/cardano-launcher/cardano-launcher.cabal
+++ b/cardano-launcher/cardano-launcher.cabal
@@ -26,7 +26,7 @@ library
     , Cardano.Shell.Environment
     , Cardano.Shell.CLI
     , Cardano.Shell.Configuration
-    , Cardano.Shell.Types
+    , Cardano.Shell.Launcher.Types
   hs-source-dirs:
       src
   build-depends:
@@ -84,6 +84,8 @@ executable cardano-launcher
     , text
     , silently
     , Cabal
+    -- cli
+    , optparse-applicative
 
   if os(windows)
     ghc-options: -optl-mwindows

--- a/cardano-launcher/src/Cardano/Shell/Launcher.hs
+++ b/cardano-launcher/src/Cardano/Shell/Launcher.hs
@@ -33,7 +33,7 @@ import           Turtle (system)
 import           Cardano.Shell.Configuration (ConfigurationOptions (..),
                                               WalletArguments (..),
                                               WalletPath (..))
-import           Cardano.Shell.Types (LoggingDependencies (..))
+import           Cardano.Shell.Launcher.Types (LoggingDependencies (..))
 import           Cardano.Shell.Update.Lib (RemoveArchiveAfterInstall (..),
                                            RunUpdateFunc, UpdaterData (..),
                                            runUpdater)

--- a/cardano-launcher/src/Cardano/Shell/Launcher/Types.hs
+++ b/cardano-launcher/src/Cardano/Shell/Launcher/Types.hs
@@ -1,5 +1,5 @@
 -- | General types for both the update and the launcher.
-module Cardano.Shell.Types
+module Cardano.Shell.Launcher.Types
     ( LoggingDependencies (..)
     , nullLogging
     ) where

--- a/cardano-launcher/src/Cardano/Shell/Update/Lib.hs
+++ b/cardano-launcher/src/Cardano/Shell/Update/Lib.hs
@@ -40,7 +40,7 @@ import           System.Win32.Process (getCurrentProcessId)
 
 import           Test.QuickCheck (Arbitrary (..), oneof)
 
-import           Cardano.Shell.Types (LoggingDependencies (..))
+import           Cardano.Shell.Launcher.Types (LoggingDependencies (..))
 
 
 -- We need to add the check if the archive exists first!

--- a/cardano-launcher/test/LauncherSpec.hs
+++ b/cardano-launcher/test/LauncherSpec.hs
@@ -27,7 +27,7 @@ import           Cardano.Shell.Launcher (DaedalusExitCode (..),
                                          TLSPath (..), UpdateRunner (..),
                                          generateTlsCertificates,
                                          handleDaedalusExitCode)
-import           Cardano.Shell.Types (nullLogging)
+import           Cardano.Shell.Launcher.Types (nullLogging)
 
 -- | The simple launcher spec.
 launcherSpec :: Spec

--- a/cardano-launcher/test/UpdaterSpec.hs
+++ b/cardano-launcher/test/UpdaterSpec.hs
@@ -10,7 +10,7 @@ import           Test.Hspec.QuickCheck (prop)
 import           Test.QuickCheck (Arbitrary (..), elements, (===))
 import           Test.QuickCheck.Monadic (assert, monadicIO, run)
 
-import           Cardano.Shell.Types (nullLogging)
+import           Cardano.Shell.Launcher.Types (nullLogging)
 import           Cardano.Shell.Update.Lib (RemoveArchiveAfterInstall (..),
                                            UpdateOSPlatform (..),
                                            UpdaterData (..), executeUpdater,

--- a/nix/.stack.nix/cardano-launcher.nix
+++ b/nix/.stack.nix/cardano-launcher.nix
@@ -51,6 +51,7 @@
             (hsPkgs.text)
             (hsPkgs.silently)
             (hsPkgs.Cabal)
+            (hsPkgs.optparse-applicative)
             ];
           };
         "mock-daedalus-frontend" = {


### PR DESCRIPTION
https://github.com/input-output-hk/cardano-shell/issues/337

This enables testing from the CLI.
I also had to refactor the `CLI` module a bit, the CLI belongs at the top level.

If you want to provide stubbed exit codes, you can use something like:
```
stack exec cardano-launcher -- --config ./cardano-launcher/configuration/launcher/launcher-config.demo.yaml --wallet-exit-codes "[CLIExitCodeFailure 21, CLIExitCodeFailure 22, CLIExitCodeFailure 20, CLIExitCodeSuccess]" --updater-exit-codes "[CLIExitCodeFailure 1, CLIExitCodeSuccess]"
```

The exit codes are being popped from the list in order in which they were submitted. The result of this run is:
```
stack exec cardano-launcher -- --config ./cardano-launcher/configuration/launcher/launcher-config.demo.yaml --wallet-exit-codes "[CLIExitCodeFailure 21, CLIExitCodeFailure 22, CLIExitCodeFailure 20, CLIExitCodeSuccess]" --updater-exit-codes "[CLIExitCodeFailure 1, CLIExitCodeSuccess]"
LauncherCLI {launcherConfigPath = LauncherOptionPath {getLauncherOptionPath = "./cardano-launcher/configuration/launcher/launcher-config.demo.yaml"}, walletExitCodes = Just [CLIExitCodeFailure 21,CLIExitCodeFailure 22,CLIExitCodeFailure 20,CLIExitCodeSuccess], updaterExitCodes = Just [CLIExitCodeFailure 1,CLIExitCodeSuccess]}
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.63 UTC] Starting cardano-launcher
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.64 UTC] Launcher substituted ENV variables: Object (fromList [("walletLogging",Bool False),("nodeArgs",Array [String "--tlsca",String "/home/ksaric/.local/share/Daedalus/mainnet/tls/server/ca.crt",String "--tlscert",String "/home/ksaric/.local/share/Daedalus/mainnet/tls/server/server.crt",String "--tlskey",String "/home/ksaric/.local/share/Daedalus/mainnet/tls/server/server.key",String "--no-client-auth",String "--log-console-off",String "--update-server",String "https://update-cardano-mainnet.iohk.io",String "--keyfile",String "/home/ksaric/.local/share/Daedalus/mainnet/Secrets/secret.key",String "--topology",String ".//wallet-topology.yaml",String "--wallet-db-path",String "/home/ksaric/.local/share/Daedalus/mainnet/Wallet",String "--update-latest-path",String "/home/ksaric/.local/share/Daedalus/mainnet/installer.sh",String "--wallet-address",String "127.0.0.1:0",String "--update-with-package"]),("statePath",String "/home/ksaric/.local/share/Daedalus/mainnet"),("walletPath",String "./cardano-launcher/test/testDaedalusFrontend.sh"),("nodePath",String "cardano-node"),("launcherLogsPrefix",String "/home/ksaric/.local/share/Daedalus/mainnet/Logs/"),("walletArgs",Array []),("nodeDbPath",String "/home/ksaric/.local/share/Daedalus/mainnet/DB/"),("updaterPath",String "bash"),("workingDir",String "./"),("frontendOnlyMode",Bool True),("nodeLogPath",Null),("updaterArgs",Array [String "main"]),("logsPrefix",String "/home/ksaric/.local/share/Daedalus/mainnet/Logs"),("configuration",Object (fromList [("seed",Null),("filePath",String "./cardano-launcher/configuration/cert-configuration.yaml"),("key",String "dev"),("systemStart",Null)])),("updateArchive",String "./cardano-launcher/test/testUpdater.sh"),("nodeLogConfig",String ".//log-config-prod.yaml"),("nodeTimeoutSec",Number 60.0),("tlsPath",String "./configuration"),("x509ToolPath",String "cardano-x509-certificates")])
[iohk.launcher:Info:15] [2019-10-29 12:47:56.64 UTC] Generating the certificates!
[iohk.launcher:Info:15] [2019-10-29 12:47:56.78 UTC] Does update installation exist: UpdaterExists
[iohk.launcher:Info:15] [2019-10-29 12:47:56.78 UTC] Running UNIX update.
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Starting the wallet with arguments: WalletArguments {getWalletArguments = []}
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Wallet exited with exitcode: ExitFailure 21
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Restart Daedalus in GPU safe mode
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Starting the wallet with arguments: WalletArguments {getWalletArguments = ["--safe-mode","--disable-gpu","--disable-d3d11"]}
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Wallet exited with exitcode: ExitFailure 22
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Restart Daedalus in normal mode
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Starting the wallet with arguments: WalletArguments {getWalletArguments = []}
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Wallet exited with exitcode: ExitFailure 20
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Running the update system
[iohk.launcher:Info:15] [2019-10-29 12:47:56.78 UTC] Does update installation exist: UpdaterExists
[iohk.launcher:Info:15] [2019-10-29 12:47:56.78 UTC] Running UNIX update.
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Starting the wallet with arguments: WalletArguments {getWalletArguments = []}
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Wallet exited with exitcode: ExitSuccess
[iohk.launcher:Notice:15] [2019-10-29 12:47:56.78 UTC] Daedalus exited with ExitSuccess, will shutdown cardano-launcher
```

Now we can cover all the state machine scenarios on all platforms!

The full state machine diagram:
![image](https://user-images.githubusercontent.com/6264437/67771018-c6727780-fa57-11e9-85f7-56df7292282f.png)
