### PR TITLE
update dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -10,7 +10,13 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 12ab51e27539c9cce042ded0c89efc0ccae6137a
+  tag: ad19158c7599bc5d50fe7cb0111a1488a139a381
+
+source-repository-package
+  type: git
+  location: https://github.com/input-output-hk/cardano-prelude
+  tag: ad19158c7599bc5d50fe7cb0111a1488a139a381
+  subdir: test
 
 source-repository-package
   type: git
@@ -21,11 +27,11 @@ source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir: iohk-monitoring
-  tag: 1ebe57df3a76a8ae4e3b5a31a9b85132f71534fc
+  tag: b4268cedecbbe2a35437effc17a8af10abda8ea8
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
   subdir:   contra-tracer
-  tag: 1ebe57df3a76a8ae4e3b5a31a9b85132f71534fc
+  tag: b4268cedecbbe2a35437effc17a8af10abda8ea8
 

--- a/nix/.stack.nix/cardano-prelude-test.nix
+++ b/nix/.stack.nix/cardano-prelude-test.nix
@@ -42,8 +42,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "12ab51e27539c9cce042ded0c89efc0ccae6137a";
-      sha256 = "1j8ac1286grk3c9j10i7az30q6f605r7d302hnd22c9pzj7c0lhy";
+      rev = "ad19158c7599bc5d50fe7cb0111a1488a139a381";
+      sha256 = "172il8sw6ip84mfw1gvrrqm10vb3hccphj4v4jqyqdjxshmj1r8g";
       });
     postUnpack = "sourceRoot+=/test; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/cardano-prelude.nix
+++ b/nix/.stack.nix/cardano-prelude.nix
@@ -60,6 +60,7 @@
             (hsPkgs.pretty-show)
             (hsPkgs.QuickCheck)
             (hsPkgs.quickcheck-instances)
+            (hsPkgs.random)
             (hsPkgs.text)
             (hsPkgs.template-haskell)
             (hsPkgs.time)
@@ -70,7 +71,7 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/cardano-prelude";
-      rev = "12ab51e27539c9cce042ded0c89efc0ccae6137a";
-      sha256 = "1j8ac1286grk3c9j10i7az30q6f605r7d302hnd22c9pzj7c0lhy";
+      rev = "ad19158c7599bc5d50fe7cb0111a1488a139a381";
+      sha256 = "172il8sw6ip84mfw1gvrrqm10vb3hccphj4v4jqyqdjxshmj1r8g";
       });
     }

--- a/nix/.stack.nix/contra-tracer.nix
+++ b/nix/.stack.nix/contra-tracer.nix
@@ -24,8 +24,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "1ebe57df3a76a8ae4e3b5a31a9b85132f71534fc";
-      sha256 = "0vwl94sda973009746n3l5n8kjlr6fajrazg7sya8plpm4x9v12l";
+      rev = "b4268cedecbbe2a35437effc17a8af10abda8ea8";
+      sha256 = "0pgzw5xc6dxp5yykgbr3bpr68vfpf4lmmbfhid3f2mrn58q7q0bw";
       });
     postUnpack = "sourceRoot+=/contra-tracer; echo source root reset to \$sourceRoot";
     }

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -2,6 +2,7 @@
   extras = hackage:
     {
       packages = {
+        "katip" = (((hackage.katip)."0.8.3.0").revisions).default;
         "quickcheck-state-machine" = (((hackage.quickcheck-state-machine)."0.6.0").revisions).default;
         "pretty-show" = (((hackage.pretty-show)."1.9.5").revisions).default;
         "time-units" = (((hackage.time-units)."1.0.0").revisions).default;

--- a/nix/.stack.nix/iohk-monitoring.nix
+++ b/nix/.stack.nix/iohk-monitoring.nix
@@ -93,8 +93,8 @@
     } // {
     src = (pkgs.lib).mkDefault (pkgs.fetchgit {
       url = "https://github.com/input-output-hk/iohk-monitoring-framework";
-      rev = "1ebe57df3a76a8ae4e3b5a31a9b85132f71534fc";
-      sha256 = "0vwl94sda973009746n3l5n8kjlr6fajrazg7sya8plpm4x9v12l";
+      rev = "b4268cedecbbe2a35437effc17a8af10abda8ea8";
+      sha256 = "0pgzw5xc6dxp5yykgbr3bpr68vfpf4lmmbfhid3f2mrn58q7q0bw";
       });
     postUnpack = "sourceRoot+=/iohk-monitoring; echo source root reset to \$sourceRoot";
     }

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,11 @@
-resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/12ab51e27539c9cce042ded0c89efc0ccae6137a/snapshot.yaml
+resolver: https://raw.githubusercontent.com/input-output-hk/cardano-prelude/ad19158c7599bc5d50fe7cb0111a1488a139a381/snapshot.yaml
 
 packages:
 - ./cardano-shell
 - ./cardano-launcher
 
 extra-deps:
+  - katip-0.8.3.0
   - quickcheck-state-machine-0.6.0  # Used a specific dependency, new release.
   - pretty-show-1.9.5               # Used for quickcheck-state-machine.
   - time-units-1.0.0
@@ -13,13 +14,13 @@ extra-deps:
   - Win32-2.5.4.1@sha256:e623a1058bd8134ec14d62759f76cac52eee3576711cb2c4981f398f1ec44b85
 
   - git: https://github.com/input-output-hk/cardano-prelude
-    commit: 12ab51e27539c9cce042ded0c89efc0ccae6137a
+    commit: ad19158c7599bc5d50fe7cb0111a1488a139a381
     subdirs:
       - .
       - test
 
   - git: https://github.com/input-output-hk/iohk-monitoring-framework
-    commit: 1ebe57df3a76a8ae4e3b5a31a9b85132f71534fc
+    commit: b4268cedecbbe2a35437effc17a8af10abda8ea8
     subdirs:
       - contra-tracer
       - iohk-monitoring


### PR DESCRIPTION
upgrade `iohk-monitoring`:
  should already clean up some problems
  like the message about not being able to remove the symlink.
  (see issue https://github.com/input-output-hk/iohk-monitoring-framework/issues/452)

upgrade `cardano-prelude`:
  to same revision that cardano-node uses