### PR TITLE
Fix coverall tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,6 @@ steps:
   - label: 'stack coveralls coverage'
     command:
       - 'nix-shell -A runCoveralls'
-    soft_fail:
-      - exit_status: '*'
     agents:
       system: x86_64-linux
 

--- a/cabal.project
+++ b/cabal.project
@@ -21,6 +21,10 @@ package cardano-launcher
 
 -- ---------------------------------------------------------
 
+-- The iohk-monitoring requires async-timer >= 0.2.0.0 but does not
+-- list this constraint in it's cabal file.
+constraints: async-timer >= 0.2.0.0
+
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl-x509

--- a/default.nix
+++ b/default.nix
@@ -19,9 +19,10 @@ let
 
   haskellPackages = recRecurseIntoAttrs
     # the Haskell.nix package set, reduced to local packages.
-    (selectProjectPackages cardanoNodeHaskellPackages);
+    (selectProjectPackages cardanoShellHaskellPackages);
 
   self = {
+    inherit cardanoShellHaskellPackages;
     inherit haskellPackages hydraEvalErrors;
 
     inherit (haskellPackages.cardano-shell.identifier) version;

--- a/default.nix
+++ b/default.nix
@@ -44,8 +44,10 @@ let
 
     runCoveralls = pkgs.stdenv.mkDerivation {
       name = "run-coveralls";
-      buildInputs = with pkgs; [ commonLib.stack-hpc-coveralls stack ];
+      buildInputs = [ commonLib.stack-hpc-coveralls stack_1_9_3 nix ];
       shellHook = ''
+        export GIT_SSL_CAINFO="${cacert}/etc/ssl/certs/ca-bundle.crt"
+
         echo '~~~ stack nix test'
         stack test --nix --coverage
         echo '~~~ shc'

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -38,6 +38,15 @@ let
       })
       # And, of course, our haskell-nix-ified cabal project:
       (import ./pkgs.nix)
+      # stack needs to be version 1.9.3, because versions greater than
+      # this can't be re-execed in a nix shell:
+      #
+      # https://github.com/commercialhaskell/stack/issues/5000
+      #
+      # i.e. "runCoveralls" fails with stack > 1.9.3
+      (self: super: {
+        stack_1_9_3 = (import sources."nixpkgs-19.03" {}).stack;
+      })
     ];
 
   pkgs = import nixpkgs {

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,6 +1,6 @@
 # our packages overlay
 pkgs: _: with pkgs; {
-  cardanoNodeHaskellPackages = import ./haskell.nix {
+  cardanoShellHaskellPackages = import ./haskell.nix {
     inherit config
       lib
       stdenv

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -22,5 +22,17 @@
         "type": "tarball",
         "url": "https://github.com/input-output-hk/iohk-nix/archive/b2b9c8e24d694a9c7ccf76ea175eba8493f3ab2a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs-19.03": {
+        "branch": "nixos-19.03",
+        "description": "Nix Packages collection",
+        "homepage": null,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "34c7eb7545d155cc5b6f499b23a7cb1c96ab4d59",
+        "sha256": "11z6ajj108fy2q5g8y4higlcaqncrbjm3dnv17pvif6avagw4mcb",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/34c7eb7545d155cc5b6f499b23a7cb1c96ab4d59.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/shell.nix
+++ b/shell.nix
@@ -23,25 +23,28 @@ let
     ];
 
     # These programs will be available inside the nix-shell.
-    buildInputs = with haskellPackages; [
+    buildInputs = (with haskellPackages; [
+      profiteur
+      weeder
+    ]) ++ (with pkgs; [
       cabal-install
       ghcid
+      git
       hlint
-      weeder
-      nix
       niv
+      nix
       pkgconfig
-      profiteur
       sqlite-interactive
       tmux
-      git
-    ];
+    ]);
 
     # Prevents cabal from choosing alternate plans, so that
     # *all* dependencies are provided by Nix.
     exactDeps = true;
 
     inherit withHoogle;
+
+    GIT_SSL_CAINFO = "${cacert}/etc/ssl/certs/ca-bundle.crt";
   };
 
   devops = pkgs.stdenv.mkDerivation {

--- a/shell.nix
+++ b/shell.nix
@@ -12,7 +12,7 @@ with pkgs;
 let
   # This provides a development environment that can be used with nix-shell or
   # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
-  shell = cardanoNodeHaskellPackages.shellFor {
+  shell = cardanoShellHaskellPackages.shellFor {
     name = "cabal-dev-shell";
 
     # If shellFor local packages selection is wrong,


### PR DESCRIPTION
Fixes the coverall tests broken in #362:
  - Uses an older version of Stack, as newer versions have unresolved issues executing in a nix-shell.
  - Adds an extra constraint to the cabal plan, as the upstream "iohk-monitoring" package is missing that constraint.

This is only a temporary fix. The stack build isn't reproducible, and in fact this PR wasn't working yesterday, so the stack runCoveralls tests rely on some unreliable environment, which is not ideal for CI. Our next step is to add coverage support to haskell.nix and use that to generate the coverage reports here (https://github.com/input-output-hk/haskell.nix/issues/443).