### PR TITLE
Use haskell.nix for coverage

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,7 @@
 steps:
-  # TODO: @craige fix this
-  - label: 'stack coveralls coverage'
+  - label: 'coveralls coverage'
     command:
-      - 'nix-shell -A runCoveralls'
+      - '$(nix-build -A uploadCoverallsScript --arg config "{ haskellNix = { coverage = true; }; }")/bin/uploadCoveralls.sh'
     agents:
       system: x86_64-linux
 

--- a/README.rst
+++ b/README.rst
@@ -148,3 +148,26 @@ these tools in the project repo:
 .. |cardano-shell| image:: https://user-images.githubusercontent.com/6264437/47286557-70baf200-d5ef-11e8-8fe7-8584a9d6ae44.jpg
 .. |cardano-shell-responsibilities| image:: https://user-images.githubusercontent.com/6264437/47286789-736a1700-d5f0-11e8-9056-514101b237f0.jpg
 .. |cardano-shell-integration| image:: https://user-images.githubusercontent.com/6264437/47286815-88df4100-d5f0-11e8-92a7-c807b6d3b47a.jpg
+
+Coverage
+~~~~~~~~
+
+You can generate a coverage report for the entire project like so:
+
+::
+
+   nix-build -A cardanoShellHaskellPackages.projectCoverageReport --arg config "{ haskellNix = { coverage = true; }; }"
+
+or for each package like this:
+
+::
+
+   nix-build -A cardanoShellHaskellPackages.cardano-shell.coverageReport --arg config "{ haskellNix = { coverage = true; }; }"
+   nix-build -A cardanoShellHaskellPackages.cardano-launcher.coverageReport --arg config "{ haskellNix = { coverage = true; }; }"
+
+The CI is currently configured to upload a project coverage report to
+a coverage web service. It does this using the script provided by:
+
+::
+
+   $(nix-build -A uploadCoverallsScript --arg config "{ haskellNix = { coverage = true; }; }")/bin/uploadCoveralls.sh

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -7,7 +7,7 @@ let
   sources = import ./sources.nix { inherit pkgs; }
     // sourcesOverride;
   iohkNix = import sources.iohk-nix {};
-  haskellNix = import sources."haskell.nix";
+  haskellNix = import sources."haskell.nix" {};
   # use our own nixpkgs if it exists in our sources,
   # otherwise use iohkNix default nixpkgs.
   nixpkgs = if (sources ? nixpkgs)

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -10,6 +10,8 @@
 , compiler ? config.haskellNix.compiler or "ghc865"
 # Enable profiling
 , profiling ? config.haskellNix.profiling or false
+# Enable coverage
+, coverage ? config.haskellNix.coverage or false
 }:
 let
   src = haskell-nix.haskellLib.cleanGit {
@@ -25,6 +27,7 @@ let
     ghc = buildPackages.haskell-nix.compiler.${compiler};
   } // {
     inherit src;
+    compiler-nix-name = compiler;
     modules = [
       { compiler.nix-name = compiler; }
 
@@ -78,6 +81,10 @@ let
         packages.lens.package.buildType = lib.mkForce "Simple";
         packages.nonempty-vector.package.buildType = lib.mkForce "Simple";
         packages.semigroupoids.package.buildType = lib.mkForce "Simple";
+      })
+      (lib.optionalAttrs coverage {
+        packages.cardano-launcher.components.library.doCoverage = true;
+        packages.cardano-shell.components.library.doCoverage = true;
       })
     ];
     # TODO add flags to packages (like cs-ledger) so we can turn off tests that will

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "285b4ae6ef222c299c100ae0d89e5060f6b0c879",
-        "sha256": "0dppnh7iigyxm5904g6a8m919zixsad3hbr8y6bphqia28glm0fa",
+        "rev": "48b8674f5f726cfb5083c025d3c53ff01fef009a",
+        "sha256": "0b90xnxn72kv5qskp3gxfcmql8cqbank7nlp0m6353yhqp6kr5mc",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/285b4ae6ef222c299c100ae0d89e5060f6b0c879.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/48b8674f5f726cfb5083c025d3c53ff01fef009a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "b2b9c8e24d694a9c7ccf76ea175eba8493f3ab2a",
-        "sha256": "17bms19x7k12pd009qa8wyyk3sgk7cxpgp6spc7czn0lw3i5ma9f",
+        "rev": "f4790863d0d4e3f9018f012ec6575432c7952a48",
+        "sha256": "0jds3j5fqcwbgpmbddrp9cxia5mxz8kw7sqsw6jcq9bq5mv1x00d",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/b2b9c8e24d694a9c7ccf76ea175eba8493f3ab2a.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/f4790863d0d4e3f9018f012ec6575432c7952a48.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-19.03": {


### PR DESCRIPTION
- This is a small commit that makes two changes:
  - Uses haskell.nix's new support for coverage to generate the
    coverage report rather than using stack. As the CI already uses
    haskell.nix to build the project and it's dependencies, this
    should be faster than starting from scratch with stack. The
    dependencies will be cached, so only the library needs to be
    rebuilt with coverage support on.
    - The coverage report generated by stack and generated by this
      method are byte-for-byte the same.
  - Implements a small conceptual shift in how we generate coverage
    reports. Rather than generating the coverage report and uploading
    it to coveralls.io from within Nix (this is not reproducible:
    querying a web API could fail), we instead have Nix generate a
    script that when run, will upload the coverage report. The script
    generation is reproducible, hence we keep it inside Nix. The
    script execution is not, so we run the script outside of Nix (in
    the buildkite pipeline).
- Added coverage doco to the README.rst