### PR TITLE
Remove bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,9 +1,0 @@
-status = [
-  "buildkite/cardano-shell",
-  "ci/hydra-eval",
-  "ci/hydra:Cardano:cardano-shell:required",
-]
-timeout_sec = 7200
-required_approvals = 1
-block_labels = [ "WIP", "DO NOT MERGE" ]
-delete_merged_branches = true


### PR DESCRIPTION
This is not a high-activity repo and bors doesn't seem to be used much for merging recent PRs. It's simpler just to disable bors.