### PR TITLE
Upgrade ghc to 8.10.6

### DIFF
--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -24,9 +24,9 @@
         cardano-sl-x509 = ./cardano-sl-x509.nix;
         cardano-crypto = ./cardano-crypto.nix;
         };
-      compiler.version = "8.6.5";
-      compiler.nix-name = "ghc865";
+      compiler.version = "8.10.6";
+      compiler.nix-name = "ghc810";
       };
   resolver = "lts-13.26";
-  compiler = "ghc-8.6.5";
+  compiler = "ghc-8.10.6";
   }


### PR DESCRIPTION
We are assuming that upgrading ghc will solve Issues in our CI

`‘bridgeTable.cardano.aarch64-darwin’: error: cannot coerce null to a string`
https://ci.zw3rk.com/jobset/daedalus/daedalus-ddw-745-arm-support#tabs-errors