### PR TITLE
[DDW-691] Allow 2nd instance in a specific case – when provided with a `web+cardano://` URL

### DIFF
--- a/cardano-launcher/app/Main.hs
+++ b/cardano-launcher/app/Main.hs
@@ -43,7 +43,6 @@ import           Cardano.Shell.Launcher (LoggingDependencies (..), TLSError,
 import           Cardano.Shell.Update.Lib (UpdaterData (..),
                                            runDefaultUpdateProcess)
 import           Cardano.X509.Configuration (TLSConfiguration)
-import           Control.Exception.Safe (throwM)
 import           Control.Exception.Safe as E
 
 import           System.FilePath ((</>))

--- a/cardano-launcher/app/Main.hs
+++ b/cardano-launcher/app/Main.hs
@@ -123,7 +123,7 @@ main = silence $ do
         setEnv "LC_ALL" "en_GB.UTF-8"
         setEnv "LANG"   "en_GB.UTF-8"
 
-        launcherOptions <- do
+        (launcherOptions, mURL) <- do
             eLauncherOptions <- getLauncherOptions loggingDependencies (launcherConfigPath launcherCLI)
             case eLauncherOptions of
                 Left err -> do
@@ -192,6 +192,7 @@ main = silence $ do
                         updaterExecutionFunction
                         updaterData
                         stateDir
+                        mURL
 
         -- release the lock on the lock file
         hClose lockHandle

--- a/cardano-launcher/cardano-launcher.cabal
+++ b/cardano-launcher/cardano-launcher.cabal
@@ -67,6 +67,7 @@ library
                        -Wincomplete-uni-patterns
                        -Wredundant-constraints
                        -Wpartial-fields
+                       -Wno-name-shadowing
 
 executable cardano-launcher
   main-is: Main.hs

--- a/cardano-launcher/src/Cardano/Shell/Application.hs
+++ b/cardano-launcher/src/Cardano/Shell/Application.hs
@@ -1,5 +1,6 @@
 module Cardano.Shell.Application
     ( checkIfApplicationIsRunning
+    , ApplicationError(ApplicationAlreadyRunningException)
     ) where
 
 import           Cardano.Prelude

--- a/cardano-launcher/src/Cardano/Shell/Configuration.hs
+++ b/cardano-launcher/src/Cardano/Shell/Configuration.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RecordWildCards            #-}
 
 module Cardano.Shell.Configuration
     ( WalletArguments (..)
@@ -57,26 +58,17 @@ data LauncherOptions = LauncherOptions
 instance FromJSON LauncherOptions where
     parseJSON = withObject "LauncherOptions" $ \o -> do
 
-        daedalusBin         <- o .: "daedalusBin"
-        updaterPath         <- o .: "updaterPath"
-        updaterArgs         <- o .: "updaterArgs"
-        updateArchive       <- o .: "updateArchive"
-        configuration       <- o .:? "configuration"
-        tlsPath             <- o .:? "tlsPath"
-        tlsConfig           <- o .:? "tlsConfig"
-        workingDir          <- o .: "workingDir"
-        stateDir            <- o .: "stateDir"
+        loConfiguration     <- o .:? "configuration"
+        loTlsPath           <- o .:? "tlsPath"
+        loTlsConfig         <- o .:? "tlsConfig"
+        loUpdaterPath       <- o .: "updaterPath"
+        loUpdaterArgs       <- o .: "updaterArgs"
+        loUpdateArchive     <- o .: "updateArchive"
+        loDaedalusBin       <- o .: "daedalusBin"
+        loWorkingDirectory  <- o .: "workingDir"
+        loStateDir          <- o .: "stateDir"
 
-        pure $ LauncherOptions
-            configuration
-            tlsPath
-            tlsConfig
-            updaterPath
-            updaterArgs
-            updateArchive
-            daedalusBin
-            workingDir
-            stateDir
+        pure $ LauncherOptions{..}
 
 -- | Configuration yaml file location and the key to use. The file should
 -- parse to a MultiConfiguration and the 'cfoKey' should be one of the keys

--- a/cardano-launcher/src/Cardano/Shell/Launcher.hs
+++ b/cardano-launcher/src/Cardano/Shell/Launcher.hs
@@ -205,6 +205,7 @@ runWalletProcess
     -> RunUpdateFunc
     -> UpdaterData
     -> FilePath
+    -> Maybe Text
     -> IO ExitCode
 runWalletProcess
     logDep
@@ -213,7 +214,8 @@ runWalletProcess
     walletRunner
     runUpdateFunc
     updaterData
-    stateDir = do
+    stateDir
+    mURL = do
 
     -- Parametrized by @WalletMode@ so we can change it on restart depending
     -- on the Daedalus exit code.
@@ -228,16 +230,17 @@ runWalletProcess
                         runUpdateFunc
                         updaterData
                         stateDir
+                        mURL
 
     -- Additional arguments we need to pass if it's a SAFE mode.
-    let walletSafeModeArgs :: WalletArguments
-        walletSafeModeArgs = WalletArguments [ "--safe-mode" ]
+    let walletSafeModeArgs :: [Text]
+        walletSafeModeArgs = [ "--safe-mode" ]
 
     -- Daedalus safe mode.
     let walletArgs :: WalletArguments
-        walletArgs =    if walletMode == WalletModeSafe
+        walletArgs =  WalletArguments $ (if walletMode == WalletModeSafe
                             then walletSafeModeArgs
-                            else WalletArguments []
+                            else []) <> maybeToList mURL
 
     logNotice logDep $ "Starting the wallet with arguments: " <> Cardano.Prelude.show walletArgs
 
@@ -314,8 +317,9 @@ runLauncher
     -> RunUpdateFunc
     -> UpdaterData
     -> FilePath
+    -> Maybe Text
     -> IO ExitCode
-runLauncher loggingDependencies walletRunner daedalusBin runUpdateFunc updaterData stateDir = do
+runLauncher loggingDependencies walletRunner daedalusBin runUpdateFunc updaterData stateDir mURL = do
         safeMode <- readSafeMode stateDir
 
         -- In the case the user wants to avoid installing the update now, we
@@ -335,6 +339,7 @@ runLauncher loggingDependencies walletRunner daedalusBin runUpdateFunc updaterDa
             runUpdateFunc
             updaterData
             stateDir
+            mURL
 
 -- | Generation of the TLS certificates.
 -- This just covers the generation of the TLS certificates and nothing else.

--- a/cardano-launcher/test/LauncherSpec.hs
+++ b/cardano-launcher/test/LauncherSpec.hs
@@ -172,14 +172,14 @@ configurationSpec = describe "configuration files" $ modifyMaxSuccess (const 1) 
         it "should fail due to passing wrong file path" $ monadicIO $ do
             eLauncherOption <- run $ do
                 -- Path to the launcher file is incorrect
-                let launcherOptionPath = LauncherOptionPath "this will fail"
+                let launcherOptionPath = LauncherOptionPath "this will fail" Nothing
                 withSystemTempDirectory "test-XXXXXX" $ \tmpDir ->
                     withSetEnvs launcherOptionPath tmpDir $ decodeLauncherOption nullLogging launcherOptionPath
             assert $ isLeft eLauncherOption
 
         it "should fail due to missing env vars" $ monadicIO $ do
             eLauncherOption <- run $ do
-                let launcherOptionPath = LauncherOptionPath (configFullFilePath "launcher-config-mainnet.linux.yaml")
+                let launcherOptionPath = LauncherOptionPath (configFullFilePath "launcher-config-mainnet.linux.yaml") Nothing
                 -- Not environment variables are set!
                 decodeLauncherOption nullLogging launcherOptionPath
             assert $ isLeft eLauncherOption
@@ -191,7 +191,7 @@ configurationSpec = describe "configuration files" $ modifyMaxSuccess (const 1) 
                     let val = String "this is not launcher option"
                     let yamlPath = tmpDir </> "launcher.yaml"
                     encodeFile yamlPath val
-                    let launcherOptionPath = LauncherOptionPath yamlPath
+                    let launcherOptionPath = LauncherOptionPath yamlPath Nothing
                     withSetEnvs launcherOptionPath tmpDir $ decodeLauncherOption nullLogging launcherOptionPath
             assert $ isLeft eLauncherOption
 
@@ -199,7 +199,7 @@ configurationSpec = describe "configuration files" $ modifyMaxSuccess (const 1) 
 testGetLauncherOption :: FilePath -> Spec
 testGetLauncherOption configPath = it ("should be able to perform env substitution on config: " <> configPath) $ monadicIO $ do
     eLauncherOption <- run $ do
-        let launcherOptionPath = LauncherOptionPath (configFullFilePath configPath)
+        let launcherOptionPath = LauncherOptionPath (configFullFilePath configPath) Nothing
         withSystemTempDirectory "test-XXXXXX" $ \tmpDir ->
             withSetEnvs launcherOptionPath tmpDir $ decodeLauncherOption nullLogging launcherOptionPath
     run $ putTextLn $ show eLauncherOption

--- a/shell.nix
+++ b/shell.nix
@@ -24,7 +24,9 @@ let
 
     # These programs will be available inside the nix-shell.
     buildInputs = (with haskellPackages; [
+      hindent
       profiteur
+      stylish-haskell
       weeder
     ]) ++ (with pkgs; [
       cabal-install


### PR DESCRIPTION
Needed to make `web+cardano://` links work on Windows and Linux desktops – cf. https://github.com/input-output-hk/daedalus/pull/2606

Unfortunately, this code doesn’t build on darwin CI ≥ Big Sur, so with recent CI updates to Monterey, we also have to indirectly bump Nixpkgs here…

More details on the update in this PR → https://github.com/input-output-hk/cardano-shell/pull/389