### PR TITLE
Try to update haskell.nix, iohk-nix (and via those → Nixpkgs)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-05-15T00:00:00Z
+index-state: 2021-10-10T00:00:00Z
 
 packages:
   cardano-shell
@@ -28,21 +28,17 @@ constraints: async-timer >= 0.2.0.0
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-sl-x509
-  tag: 43a036c5bbe68ca2e9cbe611eab7982e2348fe49
-  --sha256: 1aw7ns8lv51fjf45k8yzils2j7a6bqzy8hn65kb3z0dn1qsm8x88
+  tag: 12925934c533b3a6e009b61ede555f8f26bac037
+  --sha256: 1kma25g8sl6m3pgsihja7fysmv6vjdfc0x7dyky9g5z156sh8z7i
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 316c854d1d3089f480708ad5cd5ecf8a74423ddd
-  --sha256: 1srbl3jrkmpwypdz0yrx4nmah3qcsr93dp48zx2bamg51c4hcsyj
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-prelude
-  tag: 316c854d1d3089f480708ad5cd5ecf8a74423ddd
-  --sha256: 1srbl3jrkmpwypdz0yrx4nmah3qcsr93dp48zx2bamg51c4hcsyj
-  subdir: test
+  tag: c7fc9fba236972c27a55e0f3d34c2758cf616bfc
+  --sha256: 0sg1hhnifqxfc5n5f9ikbxyrjlg77hynbhsql0h4smqniw29dbwk
+  subdir:
+    cardano-prelude
+    cardano-prelude-test
 
 source-repository-package
   type: git
@@ -52,42 +48,16 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 1361bb92814c65e5964732777fc7f8ec9ebdccfe
-  --sha256: 1znl9zzw5hswcd09zcvmgq50ppp46nbzjmw67wm4wpnw5lhnlwfy
-  subdir: Win32-network
+  location: https://github.com/input-output-hk/Win32-network
+  tag: 3825d3abf75f83f406c1f7161883c438dac7277d
+  --sha256: 19wahfv726fa3mqajpqdqhnl9ica3xmf68i254q45iyjcpj1psqx
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
-  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
-  subdir: iohk-monitoring
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
-  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
-  subdir:   contra-tracer
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
-  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
-  subdir:   tracer-transformers
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/iohk-monitoring-framework
-  tag: efa4b5ecd7f0a13124616b12679cd42517cd905a
-  --sha256: 0h1h5ifl5d7dl3y6fym9pjd6rfrbh5rbyxs0xw5las503pibv2bf
-  subdir: tracer-transformers
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/ouroboros-network
-  tag: 1361bb92814c65e5964732777fc7f8ec9ebdccfe
-  --sha256: 1znl9zzw5hswcd09zcvmgq50ppp46nbzjmw67wm4wpnw5lhnlwfy
-  subdir: Win32-network
+  tag: 808724ff8a19a33d0ed06f9ef59fbd900b08553c
+  --sha256: 0298dpl29gxzs9as9ha6y0w18hqwc00ipa3hzkxv7nlfrjjz8hmz
+  subdir:
+    iohk-monitoring
+    contra-tracer
+    tracer-transformers

--- a/cardano-launcher/app/Main.hs
+++ b/cardano-launcher/app/Main.hs
@@ -14,7 +14,6 @@ import           Data.Text.Lazy.Builder (fromString, fromText)
 
 import           Distribution.System (OS (Windows), buildOS)
 import           System.Environment (setEnv)
-import           System.Exit (exitWith)
 import           System.IO.Silently (hSilence)
 import           System.Process (proc, waitForProcess, withCreateProcess)
 
@@ -23,7 +22,7 @@ import           Formatting.Buildable (Buildable (..))
 
 import           Options.Applicative (Parser, ParserInfo, auto, execParser,
                                       fullDesc, header, help, helper, info,
-                                      long, metavar, option, optional, progDesc)
+                                      long, metavar, option, progDesc)
 
 import           Cardano.BM.Setup (withTrace)
 import qualified Cardano.BM.Trace as Trace

--- a/cardano-launcher/app/Mocks/Daedalus.hs
+++ b/cardano-launcher/app/Mocks/Daedalus.hs
@@ -3,7 +3,6 @@
 module Main where
 
 import Cardano.Prelude
-import System.Exit (exitWith)
 
 seconds :: Int
 seconds = 1000000

--- a/cardano-launcher/src/Cardano/Shell/Application.hs
+++ b/cardano-launcher/src/Cardano/Shell/Application.hs
@@ -63,7 +63,7 @@ checkIfApplicationIsRunning lockFilePath = do
     when (not fileExist) $
         writeFile lockFilePath ""
 
-    lockfileHandle      <- openFile lockFilePath ReadMode
+    lockfileHandle      <- openFile lockFilePath ReadWriteMode
     isAlreadyRunning    <- hTryLock lockfileHandle ExclusiveLock
 
     -- We need to inform the user if the application version is already running.

--- a/cardano-launcher/src/Cardano/Shell/Launcher.hs
+++ b/cardano-launcher/src/Cardano/Shell/Launcher.hs
@@ -29,7 +29,7 @@ module Cardano.Shell.Launcher
 import           Cardano.Prelude hiding (onException)
 
 import           Prelude (Show (..))
-import           Data.Aeson (FromJSON, ToJSON(toJSON), genericParseJSON, genericToJSON, defaultOptions)
+import           Data.Aeson (genericParseJSON, genericToJSON, defaultOptions)
 import           Data.Yaml as Y
 import qualified System.Process as Process
 import           Turtle (system)

--- a/cardano-launcher/test/EnvironmentSpec.hs
+++ b/cardano-launcher/test/EnvironmentSpec.hs
@@ -8,7 +8,6 @@ module EnvironmentSpec
     ) where
 
 import           Cardano.Prelude
-import           Data.Char (isAlphaNum)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Vector as V
 import qualified Data.Yaml as Y

--- a/cardano-launcher/test/LauncherSMSpec.hs
+++ b/cardano-launcher/test/LauncherSMSpec.hs
@@ -18,8 +18,6 @@ module LauncherSMSpec
 
 import           Cardano.Prelude
 
-import           Data.TreeDiff (ToExpr (..))
-
 import           Test.Hspec (Spec, describe, it)
 
 import           Test.QuickCheck (Gen, Property, oneof, (===))
@@ -165,7 +163,7 @@ launcherSM = StateMachine
     , shrinker      = mShrinker
     , semantics     = mSemantics
     , mock          = mMock
-    , distribution  = Nothing
+    , cleanup       = const (pure ())
     }
   where
     -- | Let's handle just Ping/Pong for now.

--- a/cardano-launcher/test/TemplateSpec.hs
+++ b/cardano-launcher/test/TemplateSpec.hs
@@ -9,7 +9,6 @@ module TemplateSpec
     ) where
 
 import           Cardano.Prelude
-import           Data.Char (isAlphaNum)
 import           System.Environment (lookupEnv, setEnv, unsetEnv)
 import           System.IO.Error (userError)
 import           Test.Hspec (Spec)

--- a/cardano-shell/test/NodeIPCSMSpec.hs
+++ b/cardano-shell/test/NodeIPCSMSpec.hs
@@ -18,8 +18,6 @@ module NodeIPCSMSpec
 
 import           Cardano.Prelude
 
-import           Data.TreeDiff (ToExpr (..))
-
 import           Test.Hspec (Spec, describe, it)
 
 import           Test.QuickCheck (Gen, Property, arbitrary, generate, oneof,
@@ -188,7 +186,7 @@ nodeIPCSM serverHandles = StateMachine
     , shrinker      = mShrinker
     , semantics     = mSemantics
     , mock          = mMock
-    , distribution  = Nothing
+    , cleanup       = const (pure ())
     }
   where
     -- | Let's handle just Ping/Pong for now.

--- a/default.nix
+++ b/default.nix
@@ -17,6 +17,9 @@
 with pkgs; with commonLib;
 let
 
+  # FIXME: I really don’t know if this ↓ is right… – @michalrus
+  hpc-coveralls = cardanoShellHaskellPackages.tool "hpc-coveralls" "0.7.0";
+
   haskellPackages = recRecurseIntoAttrs
     # the Haskell.nix package set, reduced to local packages.
     (selectProjectPackages cardanoShellHaskellPackages);
@@ -26,7 +29,7 @@ let
       projectPkgs = selectProjectPackages pkgSet;
       projectCoverageReport = pkgSet.projectCoverageReport;
     in writeShellScriptBin "uploadCoveralls.sh" ''
-      ${commonLib.hpc-coveralls}/bin/hpc-coveralls all \
+      ${hpc-coveralls}/bin/hpc-coveralls all \
         ${concatStringsSep "\n  " (mapAttrsToList (_: p: "--package-dir .${p.src.origSubDir} \\") projectPkgs)}
         --hpc-dir ${projectCoverageReport}/share/hpc/vanilla \
         --coverage-mode StrictlyFullLines \
@@ -54,7 +57,7 @@ let
       tests = collectChecks haskellPackages;
     };
 
-    inherit (commonLib) hpc-coveralls;
+    inherit hpc-coveralls;
     uploadCoverallsScript = uploadCoverallsScript cardanoShellHaskellPackages;
 
     shell = import ./shell.nix {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,8 +6,12 @@
 let
   sources = import ./sources.nix { inherit pkgs; }
     // sourcesOverride;
-  iohkNix = import sources.iohk-nix {};
-  haskellNix = import sources."haskell.nix" {};
+  iohkNix = import sources.iohk-nix { inherit system crossSystem; };
+  haskellNix = import sources."haskell.nix" {
+    # Without that, haskell.nilx tries to call builtins.currentSystem, which fails inside flake builds:
+    pkgs = import nixpkgs { inherit system crossSystem; };
+    inherit system crossSystem;
+  };
   # use our own nixpkgs if it exists in our sources,
   # otherwise use iohkNix default nixpkgs.
   nixpkgs = if (sources ? nixpkgs)

--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -7,7 +7,7 @@
 , buildPackages
 , config ? {}
 # GHC attribute name
-, compiler ? config.haskellNix.compiler or "ghc865"
+, compiler ? config.haskellNix.compiler or "ghc8107"
 # Enable profiling
 , profiling ? config.haskellNix.profiling or false
 # Enable coverage

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "48b8674f5f726cfb5083c025d3c53ff01fef009a",
-        "sha256": "0b90xnxn72kv5qskp3gxfcmql8cqbank7nlp0m6353yhqp6kr5mc",
+        "rev": "308c937bfc68071d8ab0206b44e0f3dde35a401e",
+        "sha256": "03hkqrdjbab0m16y3bpmcg4nvrnpajkbaa595v67r77hhqja3nqj",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/48b8674f5f726cfb5083c025d3c53ff01fef009a.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/4b6ee9767daaf5fc1d5419e07733ab006b95ec93.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f4790863d0d4e3f9018f012ec6575432c7952a48",
-        "sha256": "0jds3j5fqcwbgpmbddrp9cxia5mxz8kw7sqsw6jcq9bq5mv1x00d",
+        "rev": "0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad",
+        "sha256": "09jrhq48h5vwl6vyf4q8d38vlaqmbd00m550rwxz79k90bxb7q6y",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/f4790863d0d4e3f9018f012ec6575432c7952a48.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/5e667b374153327c7bdfdbfab8ef19b1f27d4aac.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs-19.03": {


### PR DESCRIPTION
I encountered a problem – after Darwin CI update to Monterey, this code no longer compiles (actually, on anything ≥ Big Sur), failing with:

```
…
[2 of 2] Compiling Data.ByteString.Base16.Lazy ( Data/ByteString/Base16/Lazy.hs, dist/build/Data/ByteString/Base16/Lazy.o )
[2 of 2] Compiling Data.ByteString.Base16.Lazy ( Data/ByteString/Base16/Lazy.hs, dist/build/Data/ByteString/Base16/Lazy.o )
ld: file not found: /usr/lib/system/libcache.dylib for architecture x86_64
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
`cc' failed in phase `Linker'. (Exit code: 1)
builder for '/nix/store/1ibpylrkbbxpkdgf5jqkpw2p8xs1wxva-base16-bytestring-lib-base16-bytestring-0.1.1.6.drv' failed with exit code 1
…
```

This is a known error that happens in older Nixpkgs. So we need to update Nixpkgs (indirectly).

* I took `haskell.nix` and `iohk-nix` revisions from https://github.com/input-output-hk/cardano-wallet/tree/3c5f99384f16dd2af7a65528c19e5fec72d0a5cc/nix
* @hamishmack provided a working `cabal.project`
* I fixed compilation errors
* But some tests are still failing…
* `nix-build -A cardano-launcher` works, so I’m probably good w.r.t. what Daedalus needed (QA will verify there)…
* … but we need to proceed with this update…  somehow,
* also, @angerman says `iohk-nix` may be abandonware, so I guess we should get rid of this dependency? Although it has recent commits.

