### PR TITLE
Allow specifying `extraEnvVars` in `cardano-launcher` config for the wallet process

### DIFF
--- a/cardano-launcher/app/Main.hs
+++ b/cardano-launcher/app/Main.hs
@@ -11,6 +11,7 @@ import qualified Prelude
 -- Yes, we should use these seldomly but here it seems quite acceptable.
 import           Data.IORef (newIORef, readIORef, writeIORef)
 import           Data.Text.Lazy.Builder (fromString, fromText)
+import qualified Data.Map as M
 
 import           Distribution.System (OS (Windows), buildOS)
 import           System.Environment (setEnv)
@@ -130,6 +131,9 @@ main = silence $ do
                         "Error occured while parsing configuration file: " <> show err
                     throwM $ LauncherOptionsError (show err)
                 Right lo -> pure lo
+
+        forM_ (M.toList (loExtraEnvVars launcherOptions)) $ \(name, value) ->
+          setEnv (toS name) (toS value)
 
         let stateDir :: FilePath
             stateDir = loStateDir launcherOptions

--- a/cardano-launcher/cardano-launcher.cabal
+++ b/cardano-launcher/cardano-launcher.cabal
@@ -75,6 +75,7 @@ executable cardano-launcher
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
+    , containers
     , cardano-prelude
     , cardano-launcher
     , cardano-sl-x509

--- a/cardano-launcher/src/Cardano/Shell/Configuration.hs
+++ b/cardano-launcher/src/Cardano/Shell/Configuration.hs
@@ -18,6 +18,7 @@ import           Cardano.Prelude
 import           Data.Time.Units (Microsecond, fromMicroseconds)
 import           Data.Yaml (FromJSON (..), withObject, (.:), (.:?))
 import           System.Directory (doesDirectoryExist, setCurrentDirectory)
+import qualified Data.Map as M
 
 import           Cardano.Shell.Update.Lib (UpdaterData (..))
 import           Cardano.X509.Configuration (TLSConfiguration)
@@ -52,6 +53,7 @@ data LauncherOptions = LauncherOptions
     , loWorkingDirectory    :: !FilePath
     , loStateDir            :: !FilePath
     -- On WIN it should set this directory as current.
+    , loExtraEnvVars        :: !(M.Map Text Text)
     } deriving (Show, Generic)
 
 instance FromJSON LauncherOptions where
@@ -66,6 +68,7 @@ instance FromJSON LauncherOptions where
         tlsConfig           <- o .:? "tlsConfig"
         workingDir          <- o .: "workingDir"
         stateDir            <- o .: "stateDir"
+        extraEnvVars        <- o .: "extraEnvVars"
 
         pure $ LauncherOptions
             configuration
@@ -77,6 +80,7 @@ instance FromJSON LauncherOptions where
             daedalusBin
             workingDir
             stateDir
+            extraEnvVars
 
 -- | Configuration yaml file location and the key to use. The file should
 -- parse to a MultiConfiguration and the 'cfoKey' should be one of the keys

--- a/cardano-launcher/src/Cardano/Shell/Launcher.hs
+++ b/cardano-launcher/src/Cardano/Shell/Launcher.hs
@@ -49,6 +49,8 @@ import           Data.X509.Extra (genRSA256KeyPair, validateCertificate,
 import           Data.X509.Validation (FailedReason)
 import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath ((</>))
+import           System.Environment (lookupEnv)
+import qualified Data.Text as T
 
 --------------------------------------------------------------------------------
 -- Types
@@ -229,15 +231,20 @@ runWalletProcess
                         updaterData
                         stateDir
 
+    electronExtraArgv <- do
+      lookupEnv "ELECTRON_EXTRA_ARGV" >>= \case
+        Nothing -> pure []
+        Just xs -> pure . T.splitOn "\n" . T.pack $ xs
+
     -- Additional arguments we need to pass if it's a SAFE mode.
     let walletSafeModeArgs :: WalletArguments
-        walletSafeModeArgs = WalletArguments [ "--safe-mode" ]
+        walletSafeModeArgs = WalletArguments ([ "--safe-mode" ] ++ electronExtraArgv)
 
     -- Daedalus safe mode.
     let walletArgs :: WalletArguments
         walletArgs =    if walletMode == WalletModeSafe
                             then walletSafeModeArgs
-                            else WalletArguments []
+                            else WalletArguments electronExtraArgv
 
     logNotice logDep $ "Starting the wallet with arguments: " <> Cardano.Prelude.show walletArgs
 


### PR DESCRIPTION
Very useful in Lace Desktop, and we’ve been successfully running this patch for a long time now.

Let's merge it into `cardano-shell`